### PR TITLE
Added purging of Atom and RDF feeds

### DIFF
--- a/purger.php
+++ b/purger.php
@@ -208,7 +208,8 @@ namespace rtCamp\WP\Nginx {
 
 			$parse = parse_url( $url );
 
-			$_url_purge = $parse[ 'scheme' ] . '://' . $parse[ 'host' ] . '/purge' . $parse[ 'path' ];
+			$_url_purge_base = $parse[ 'scheme' ] . '://' . $parse[ 'host' ] . '/purge' . $parse[ 'path' ];
+			$_url_purge = $_url_purge_base;
 
 			if ( isset( $parse[ 'query' ] ) && $parse[ 'query' ] != '' ) {
 				$_url_purge .= '?' . $parse[ 'query' ];
@@ -217,8 +218,10 @@ namespace rtCamp\WP\Nginx {
 			$this->_do_remote_get( $_url_purge );
 
 			if ( $feed ) {
-				$feed_string = (substr( $parse[ 'path' ], -1 ) != '/') ? "/feed/" : "feed/";
-				$this->_do_remote_get( $parse[ 'scheme' ] . '://' . $parse[ 'host' ] . '/purge' . $parse[ 'path' ] . $feed_string );
+				$feed_url = rtrim( $_url_purge_base, '/' ) . '/feed/';
+				$this->_do_remote_get( $feed_url );
+				$this->_do_remote_get( $feed_url . 'atom/' );
+				$this->_do_remote_get( $feed_url . 'rdf/' );
 			}
 		}
 


### PR DESCRIPTION
This pull request is related to my question in the forum on rtCamp [1].

I’ve added lines for purging …/feed/atom/ and …/feed/rdf/ in addition to
…/feed/. The two RSS formats listed in the documentation [2] redirect to
…/feed/ on our system. Ideally, I imagine, one should somehow obtain a list
of feed URLs from Wordpress, since they may be configurable or may change
in the future.

As Pythonista, I’m not acquainted with PHP code style, but I tried to
imitate the style in the remainder of the file.

[1] http://rtcamp.com/support/topic/caching-feeds/
[2] http://codex.wordpress.org/WordPress_Feeds#Finding_Your_Feed_URL
