### PR TITLE
use function home_url() for the homepage URL for purging purposes

### DIFF
--- a/purger.php
+++ b/purger.php
@@ -102,7 +102,7 @@ namespace rtCamp\WP\Nginx {
 			$this->log( "Function purgePost BEGIN ===" );
 
 			if ( $rt_wp_nginx_helper->options[ 'purge_homepage_on_edit' ] == 1 ) {
-				$homepage_url = trailingslashit( get_option( 'siteurl' ) );
+				$homepage_url = trailingslashit( home_url() );
 
 				$this->log( "Purging homepage '$homepage_url'" );
 				$this->purgeUrl( $homepage_url );
@@ -361,7 +361,7 @@ namespace rtCamp\WP\Nginx {
 
 		private function _purge_homepage() {
 
-			$homepage_url = trailingslashit( get_option( 'siteurl' ) );
+			$homepage_url = trailingslashit( home_url() );
 
 			$this->log( sprintf( __( "Purging homepage '%s'", "rt_wp_nginx_helper" ), $homepage_url ) );
 			$this->purgeUrl( $homepage_url );


### PR DESCRIPTION
instead of using get_option ( 'siteurl' )

please see [this discussion](http://wordpress.org/support/topic/not-purging-home-page?replies=2) on wordpress.org for background.
