### PR TITLE
Fix missing wp_sanitize_redirect function call.

### DIFF
--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -324,7 +324,9 @@ namespace {
                 $status = 302;
             }
 
-            $location = wp_sanitize_redirect($location);
+            if (function_exists('wp_sanitize_redirect')) {
+                $location = wp_sanitize_redirect($location);
+            }
             header('Location: ' . $location, true, $status);
         }
 


### PR DESCRIPTION
After changing the domain of a hosted site the error described at http://wordpress.org/support/topic/call-to-undefined-function-wp_sanitize_redirect occurred.  This patch is the suggested fix from the post and has resolved the problem.

It's not clear why this only happened after changing the domain of the site.
