### PR TITLE
added rt_nginx_helper_purge_all action to expose the true_purge_all...

### DIFF
--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -72,6 +72,9 @@ namespace rtCamp\WP\Nginx {
             add_action('check_ajax_referer', array(&$rt_wp_nginx_purger, 'purge_on_check_ajax_referer'), 20, 2);
             add_action('admin_init', array(&$this, 'purge_all'));
 
+            // expose action to allow other plugins to purge the cache
+            add_action('rt_nginx_helper_purge_all', array(&$this, 'true_purge_all'));
+
             // Load WP-CLI command
             if ( defined( 'WP_CLI' ) && WP_CLI ) {
                 require_once RT_WP_NGINX_HELPER_PATH . 'wp-cli.php';
@@ -262,7 +265,6 @@ namespace rtCamp\WP\Nginx {
         }
 
         function purge_all() {
-            global $rt_wp_nginx_purger;
             if (!isset($_REQUEST['nginx_helper_action']))
                 return;
 
@@ -281,10 +283,15 @@ namespace rtCamp\WP\Nginx {
 
             switch ($action) {
                 case 'purge':
-                    $rt_wp_nginx_purger->true_purge_all();
+                    $this->true_purge_all();
                     break;
             }
             wp_redirect(add_query_arg(array('nginx_helper_action' => 'done')));
+        }
+
+        function true_purge_all() {
+            global $rt_wp_nginx_purger;
+            $rt_wp_nginx_purger->true_purge_all();
         }
 
         /**


### PR DESCRIPTION
...method so other plugins can purge the cache.  

We occasionally have items in our site's header and footer that get updated from outside sources (API calls) and right now, the nginx helper doesn't have an easy way to allow us to purge the entire cache.  We wrote some wrapper code that we can call, example:

```php
global $rt_wp_nginx_purger;
if ( ! empty( $rt_wp_nginx_purger ) && get_class( $rt_wp_nginx_purger ) === 'rtCamp\WP\Nginx\Purger' ) {
   if ( method_exists( $rt_wp_nginx_purger, 'true_purge_all' ) ) {
      @$rt_wp_nginx_purger->true_purge_all();
   }
}
```

but it's a workaround and it would be handy to be able to just fire an action and let the nginx helper plugin do the work.

```php
do_action( 'rt_nginx_helper_purge_all' );
```

This PR adds a 'rt_nginx_helper_purge_all' action that other plugins can call to fire the true_purge_all() method.
