### PR TITLE
Added the option to purge cache files directly without ngx_cache_purge

### DIFF
--- a/admin/lib/nginx-general.php
+++ b/admin/lib/nginx-general.php
@@ -48,6 +48,8 @@ namespace rtCamp\WP\Nginx {
                 $rt_wp_nginx_helper->options['purge_page_on_mod'] = ( isset( $_POST['purge_page_on_mod'] ) and ( $_POST['purge_page_on_mod'] == 1 ) ) ? 1 : 0;
                 $rt_wp_nginx_helper->options['purge_page_on_new_comment'] = ( isset( $_POST['purge_page_on_new_comment'] ) and ( $_POST['purge_page_on_new_comment'] == 1 ) ) ? 1 : 0;
                 $rt_wp_nginx_helper->options['purge_page_on_deleted_comment'] = ( isset( $_POST['purge_page_on_deleted_comment'] ) and ( $_POST['purge_page_on_deleted_comment'] == 1 ) ) ? 1 : 0;
+
+                $rt_wp_nginx_helper->options['purge_method'] = ( isset( $_POST['purge_method'] ) ) ? $_POST['purge_method'] : 'get_request';
             }
             update_site_option( 'rt_wp_nginx_helper_options', $rt_wp_nginx_helper->options );
             $update = 1;
@@ -245,6 +247,31 @@ namespace rtCamp\WP\Nginx {
                                     </label><br />
                                 </fieldset>
 
+                            </td>
+                            </tr>
+                        </table>
+                        <table class="form-table rtnginx-table">
+                            <tr valign="top">
+                                <th scope="row">
+                            <h4><?php _e('Purge Method:', 'nginx-helper'); ?></h4>
+                            </th>
+                            <td>
+                                <fieldset>
+                                    <legend class="screen-reader-text">
+                                        <span>&nbsp;<?php _e('when a post/page/custom post is published.', 'nginx-helper'); ?></span>
+                                    </legend>
+                                    <label for="purge_method_get_request">
+                                        <input type="radio" value="get_request" id="purge_method_get_request" name="purge_method"<?php checked($rt_wp_nginx_helper->options['purge_method'], 'get_request'); ?>>
+                                        &nbsp;<?php _e('Using a GET request to <strong>PURGE/url</strong> (Default option)', 'nginx-helper'); ?><br />
+                                        <small><?php _e('Uses the <strong><a href="https://github.com/FRiCKLE/ngx_cache_purge">ngx_cache_purge</a></strong> module. ', 'nginx-helper'); ?></small>
+                                    </label><br />
+                                    <label for="purge_method_unlink_files">
+                                        <input type="radio" value="unlink_files" id="purge_method_unlink_files" name="purge_method"<?php checked($rt_wp_nginx_helper->options['purge_method'], 'unlink_files'); ?>>
+                                        &nbsp;<?php _e('Delete local server cache files', 'nginx-helper'); ?><br />
+                                        <small><?php _e('Checks for matching cache file in <strong>RT_WP_NGINX_HELPER_CACHE_PATH</strong>. Does not require any other modules. Requires that the cache be stored on the same server as WordPress. You must also be using the default nginx cache options (levels=1:2) and (fastcgi_cache_key "$scheme$request_method$host$request_uri"). ', 'nginx-helper'); ?></small>
+
+                                    </label><br />
+                                </fieldset>
                             </td>
                             </tr>
                         </table>


### PR DESCRIPTION
# The issue

I needed to be able to purge cache files without using the [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge) module. 

# Solution

This pull request adds an option to the "Purge Options" area to allow the site admin to choose how cache files should be purged. The default option is to use a GET request to the /purge version of the URL, as required by ngx_cache_purge. The second option lets the plugin directly remove the cache files from the server.  

Screenshot of new option:

![screen shot 2015-04-17 at 4 07 04 pm](https://cloud.githubusercontent.com/assets/5074711/7212447/faa395a8-e51b-11e4-9d2f-c2d3e7b4421e.png)

# How it works

I followed information from [this article](https://www.digitalocean.com/community/tutorials/how-to-setup-fastcgi-caching-with-nginx-on-your-vps#purging-the-cache) to compute the correct cache file to delete. The URL to delete is hashed with md5 and then given a specific folder and file name based on that hash. 

# Caveats

In order for the "delete local files" option to work, the following must all be true:

- Cache is stored on the same server and ** RT_WP_NGINX_HELPER_CACHE_PATH** is defined. 
- Default nginx cache level must be used; `levels=1:2`
- Cache key must be: `fastcgi_cache_key "$scheme$request_method$host$request_uri"`

# Testing

So far it seems to work on my staging server tests. If someone else can help double check that everything is working great that would be much appreciated. 
