### PR TITLE
Bug fix - Can't purge because of bad url

### DIFF
--- a/admin/lib/nginx-general.php
+++ b/admin/lib/nginx-general.php
@@ -82,7 +82,7 @@ namespace rtCamp\WP\Nginx {
             </h3>
             <form id="purgeall" action="" method="post" class="clearfix">
                 <div class="inside">
-                    <?php $purge_url = esc_url( add_query_arg( array( 'nginx_helper_action' => 'purge', 'nginx_helper_urls' => 'all' ) ) ); ?>
+                    <?php $purge_url = add_query_arg( array( 'nginx_helper_action' => 'purge', 'nginx_helper_urls' => 'all' ) ); ?>
                     <?php $nonced_url = wp_nonce_url( $purge_url, 'nginx_helper-purge_all' ); ?>
                     <table class="form-table">
                         <tr valign="top">


### PR DESCRIPTION
The purge url was escaped, so the ampersand character (&) was encoded, converting the query string into a hashtag.

Signed-off-by: Javis Perez <javisperez@esd.com.do>