### PR TITLE
Updated the initial settings to include the 'purge_method' 

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -93,6 +93,8 @@ namespace rtCamp\WP\Nginx {
 		$rt_wp_nginx_helper_get_options[ 'purge_page_on_new_comment' ] = 1;
 		$rt_wp_nginx_helper_get_options[ 'purge_page_on_deleted_comment' ] = 1;
 
+                $rt_wp_nginx_helper_get_options[ 'purge_method' ] = 'get_request';
+
 		return $rt_wp_nginx_helper_get_options;
 	}
 }


### PR DESCRIPTION
On new installations, I was getting this PHP Notice

`PHP Notice:  Undefined index: purge_method in /var/www/testwp.bvm.iamme.in/htdocs/wp-content/plugins/nginx-helper/purger.php on line 213`

To fix I just added 'purge_method' to be saved with the initial options.