### PR TITLE
Missing '@' from 'opendir'

### DIFF
--- a/purger.php
+++ b/purger.php
@@ -758,7 +758,7 @@ namespace rtCamp\WP\Nginx {
 		/** Source - http://stackoverflow.com/a/1360437/156336 **/		
 		
 		function unlinkRecursive( $dir, $deleteRootToo ) {
-			if ( ! $dh = opendir( $dir ) ) {
+			if ( ! $dh = @opendir( $dir ) ) {
 				return;
 			}
 			while ( false !== ($obj = readdir( $dh )) ) {


### PR DESCRIPTION
Missing @ from opendir() cause:
```[error] 5987#5987: *321029 FastCGI sent in stderr: "PHP message: PHP Warning:  opendir(/var/run/nginx-cache): failed to open dir: No such file or directory in ...```