### PR TITLE
Add option to plugin setting to set cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Yes, it does. It physically empties the cache directory. It is set by default to
 
 If your cache directory is different, you can override this in your wp-config.php by adding
 `define('RT_WP_NGINX_HELPER_CACHE_PATH','/var/run/nginx-cache/');`
+or override this in the plugin settings. Settings in wp-config.php take precedence over plugin setting.
 
 Replace the path with your own.
 

--- a/admin/lib/nginx-general.php
+++ b/admin/lib/nginx-general.php
@@ -52,8 +52,10 @@ namespace rtCamp\WP\Nginx {
 				$rt_wp_nginx_helper->options['purge_page_on_deleted_comment'] = ( isset( $_POST['purge_page_on_deleted_comment'] ) and ( $_POST['purge_page_on_deleted_comment'] == 1 ) ) ? 1 : 0;
 
 				$rt_wp_nginx_helper->options['purge_method'] = ( isset( $_POST['purge_method'] ) ) ? $_POST['purge_method'] : 'get_request';
-                
+
                 $rt_wp_nginx_helper->options['purge_url'] = ( isset( $_POST['purge_url'] ) && ! empty( $_POST['purge_url'] ) ) ? esc_textarea( $_POST['purge_url'] ) : '';
+
+				$rt_wp_nginx_helper->options['cache_path'] = ( isset( $_POST['cache_path'] ) ) ? $_POST['cache_path'] : '/var/run/nginx-cache/';
 			}
 			if ( isset( $_POST['cache_method'] ) && $_POST['cache_method'] = "enable_redis" ) {
 				$rt_wp_nginx_helper->options['redis_hostname'] = ( isset( $_POST['redis_hostname'] ) ) ? $_POST['redis_hostname'] : '127.0.0.1';
@@ -154,9 +156,13 @@ namespace rtCamp\WP\Nginx {
 											<label for="purge_method_unlink_files">
 												<input type="radio" value="unlink_files" id="purge_method_unlink_files" name="purge_method"<?php checked( isset( $rt_wp_nginx_helper->options['purge_method'] ) ? $rt_wp_nginx_helper->options['purge_method'] : '', 'unlink_files' ); ?>>
 												&nbsp;<?php _e( 'Delete local server cache files', 'nginx-helper' ); ?><br />
-												<small><?php _e( 'Checks for matching cache file in <strong>RT_WP_NGINX_HELPER_CACHE_PATH</strong>. Does not require any other modules. Requires that the cache be stored on the same server as WordPress. You must also be using the default nginx cache options (levels=1:2) and (fastcgi_cache_key "$scheme$request_method$host$request_uri"). ', 'nginx-helper' ); ?></small>
-
+												<small><?php _e( 'Checks for matching cache file in <strong>Cache Path</strong>. Does not require any other modules. Requires that the cache be stored on the same server as WordPress. You must also be using the default nginx cache options (levels=1:2) and (fastcgi_cache_key "$scheme$request_method$host$request_uri"). ', 'nginx-helper' ); ?></small>
 											</label><br />
+											<?php if (defined('RT_WP_NGINX_HELPER_CACHE_PATH')) : ?>
+											<?php $cache_path = ( empty( $rt_wp_nginx_helper->options['cache_path'] ) ) ? '/var/run/nginx-cache/' : $rt_wp_nginx_helper->options['cache_path']; ?>
+											<label for="cache_path"><?php _e( 'Cache Path', 'nginx-helper' ); ?></label>
+											<input id="cache_path" class="medium-text" type="text" name="cache_path" value="<?php echo $cache_path; ?>" />
+											<?php endif; ?>
 										</fieldset>
 									</td>
 								</tr>
@@ -405,7 +411,7 @@ namespace rtCamp\WP\Nginx {
 						$log = fopen( $path . 'nginx.log', 'w' );
 						fclose( $log );
 					}
-					
+
 					if ( !is_writable( $path . 'nginx.log' ) ) {
 						?>
 						<span class="error fade" style="display : block"><p><?php printf( __( 'Can\'t write on log file.<br /><br />Check you have write permission on <strong>%s</strong>', 'nginx-helper' ), $rt_wp_nginx_helper->functional_asset_path() . 'nginx.log' ); ?></p></span><?php }

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -330,9 +330,6 @@ namespace rtCamp\WP\Nginx {
 
 namespace {
 
-	if ( !defined( 'RT_WP_NGINX_HELPER_CACHE_PATH' ) ) {
-		define( 'RT_WP_NGINX_HELPER_CACHE_PATH', '/var/run/nginx-cache' );
-	}
 	global $current_blog;
 
 	if ( is_admin() ) {
@@ -346,6 +343,15 @@ namespace {
 
 	global $rt_wp_nginx_helper, $rt_wp_nginx_purger, $rt_wp_nginx_compatibility;
 	$rt_wp_nginx_helper = new \rtCamp\WP\Nginx\Helper;
+
+	if ( !defined( 'RT_WP_NGINX_HELPER_CACHE_PATH' ) ) {
+		if ( $rt_wp_nginx_helper->options['cache_path']) {
+			define('RT_WP_NGINX_HELPER_CACHE_PATH',$rt_wp_nginx_helper->options['cache_path']);
+		} else
+		{
+			define('RT_WP_NGINX_HELPER_CACHE_PATH', '/var/run/nginx-cache');
+		}
+	}
 
 	if ( !empty( $rt_wp_nginx_helper->options['cache_method'] ) && $rt_wp_nginx_helper->options['cache_method'] == "enable_redis" ) {
 		$rt_wp_nginx_purger = new \rtCamp\WP\Nginx\Redispurger;

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -344,13 +344,12 @@ namespace {
 	global $rt_wp_nginx_helper, $rt_wp_nginx_purger, $rt_wp_nginx_compatibility;
 	$rt_wp_nginx_helper = new \rtCamp\WP\Nginx\Helper;
 
-	if ( !defined( 'RT_WP_NGINX_HELPER_CACHE_PATH' ) ) {
-		if ( $rt_wp_nginx_helper->options['cache_path']) {
-			define('RT_WP_NGINX_HELPER_CACHE_PATH',$rt_wp_nginx_helper->options['cache_path']);
-		} else
-		{
-			define('RT_WP_NGINX_HELPER_CACHE_PATH', '/var/run/nginx-cache');
-		}
+	if ( ! defined('RT_WP_NGINX_HELPER_CACHE_PATH') )
+	{
+		define('RT_WP_NGINX_HELPER_CACHE_PATH', '/var/run/nginx-cache');
+	} elseif ( $rt_wp_nginx_helper->options['cache_path'])
+	{
+		define('RT_WP_NGINX_HELPER_CACHE_PATH', $rt_wp_nginx_helper->options['cache_path']);
 	}
 
 	if ( !empty( $rt_wp_nginx_helper->options['cache_method'] ) && $rt_wp_nginx_helper->options['cache_method'] == "enable_redis" ) {


### PR DESCRIPTION
Allows setting the RT_WP_NGINX_HELPER_CACHE_PATH in plugin settings.
RT_WP_NGINX_HELPER_CACHE_PATH defined in wp-config.php has priority.