### PR TITLE
try to create dirs in `functional_asset_path()`

### DIFF
--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -225,11 +225,17 @@ namespace rtCamp\WP\Nginx {
 			}
 		}
 
+		/**
+		 * Returns path to functional(helper) assets directory
+		 *
+		 * @todo this could be done once on plugin init and check if wp_mkdir_p() !== true or not writable and notify admin
+		 */
 		function functional_asset_path()
 		{
 			$dir = wp_upload_dir();
-			$path = $dir['basedir'] . '/nginx-helper/';
-			return apply_filters( 'nginx_asset_path', $path );
+			$path = apply_filters( 'nginx_asset_path', $dir['basedir'] . '/nginx-helper/' );
+			wp_mkdir_p( $path );
+			return $path;
 		}
 
 		function functional_asset_url()

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -277,6 +277,11 @@ namespace rtCamp\WP\Nginx {
 
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX )
 				return;
+			if ( defined( 'DOING_CRON' ) && DOING_CRON )
+				return;
+			if ( defined( 'WP_CLI' ) && WP_CLI )
+				return;
+
 			$timestamps = "\n<!--" .
 					"Cached using Nginx-Helper on " . current_time( 'mysql' ) . ". " .
 					"It took " . get_num_queries() . " queries executed in " . timer_stop() . " seconds." .


### PR DESCRIPTION
`fopen()` using "a+" flag will only create the file it doesn't exists but not its dir path which produced a fair amount of warnings like this

```log
PHP Warning:  fopen(/var/www/web/media/sites/91/nginx-helper/nginx.log): failed to open stream: No such file or directory in /var/www/web/app/plugins/nginx-helper/purger.php on line 348
```

`wp_mkdir_p()` to the rescue.