### PR TITLE
Create new filter hook for purge urls

### DIFF
--- a/purger.php
+++ b/purger.php
@@ -780,49 +780,53 @@ namespace rtCamp\WP\Nginx {
 			return;
 		}
         
-        function purge_urls() {
+        	function purge_urls() {
 
 			global $rt_wp_nginx_helper;
 
 			$parse = parse_url( site_url() );
 
+                        $purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?
+                        	explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
+
+                        $purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls);
+
 			switch ($rt_wp_nginx_helper->options['purge_method']) {
+
 				case 'unlink_files':
 					$_url_purge_base = $parse[ 'scheme' ] . '://' . $parse[ 'host' ];
 					
-                    if( isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ) {
-                        $purge_urls = explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] );
-                        
-                        foreach ($purge_urls as $purge_url ) {
-                            $purge_url = trim( $purge_url );
-                            
-                            if( strpos( $purge_url, '*' ) === false ) {
-                                $purge_url = $_url_purge_base . $purge_url;
-                                $this->log( "- Purging URL | " . $url );
-                                $this->_delete_cache_file_for( $purge_url );
-                            }
-                        }
-                    }
+					if( is_array( $purge_urls ) && ! empty( $purge_urls ) ) {
+						foreach ($purge_urls as $purge_url ) {
+						    $purge_url = trim( $purge_url );
+						    
+						    if( strpos( $purge_url, '*' ) === false ) {
+						        $purge_url = $_url_purge_base . $purge_url;
+						        $this->log( "- Purging URL | " . $url );
+						        $this->_delete_cache_file_for( $purge_url );
+						    }
+						}
+					}
 					break;
+
 				case 'get_request':
 					// Go to default case
 				default:
 					$_url_purge_base = $parse[ 'scheme' ] . '://' . $parse[ 'host' ] . '/purge';
 					
-                    if( isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ) {
-                        $purge_urls = explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] );
-                        
-                        foreach ($purge_urls as $purge_url ) {
-                            $purge_url = trim( $purge_url );
-                            
-                            if( strpos( $purge_url, '*' ) === false ) {
-                                $purge_url = $_url_purge_base . $purge_url;
-                                $this->log( "- Purging URL | " . $url );
-                                $this->_do_remote_get( $purge_url );
-                            }
-                        }
-                    }
+					if( is_array( $purge_urls ) && ! empty( $purge_urls ) ) {
+						foreach ($purge_urls as $purge_url ) {
+						    $purge_url = trim( $purge_url );
+						    
+						    if( strpos( $purge_url, '*' ) === false ) {
+						        $purge_url = $_url_purge_base . $purge_url;
+						        $this->log( "- Purging URL | " . $url );
+						        $this->_do_remote_get( $purge_url );
+						    }
+						}
+					}
 					break;
+
 			}
 
 		}

--- a/purger.php
+++ b/purger.php
@@ -789,7 +789,8 @@ namespace rtCamp\WP\Nginx {
 			$purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?
 				explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
 
-			$purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls);
+                        // Allow plugins/themes to modify/extend urls. Pass urls array in first parameter, second says if wildcards are allowed
+			$purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls, false);
 
 			switch ($rt_wp_nginx_helper->options['purge_method']) {
 

--- a/purger.php
+++ b/purger.php
@@ -802,7 +802,7 @@ namespace rtCamp\WP\Nginx {
 						    
 						    if( strpos( $purge_url, '*' ) === false ) {
 						        $purge_url = $_url_purge_base . $purge_url;
-						        $this->log( "- Purging URL | " . $url );
+						        $this->log( "- Purging URL | " . $purge_url );
 						        $this->_delete_cache_file_for( $purge_url );
 						    }
 						}

--- a/purger.php
+++ b/purger.php
@@ -780,16 +780,16 @@ namespace rtCamp\WP\Nginx {
 			return;
 		}
         
-        	function purge_urls() {
+		function purge_urls() {
 
 			global $rt_wp_nginx_helper;
 
 			$parse = parse_url( site_url() );
 
-                        $purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?
-                        	explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
+			$purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?
+				explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
 
-                        $purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls);
+			$purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls);
 
 			switch ($rt_wp_nginx_helper->options['purge_method']) {
 

--- a/purger.php
+++ b/purger.php
@@ -820,7 +820,7 @@ namespace rtCamp\WP\Nginx {
 						    
 						    if( strpos( $purge_url, '*' ) === false ) {
 						        $purge_url = $_url_purge_base . $purge_url;
-						        $this->log( "- Purging URL | " . $url );
+						        $this->log( "- Purging URL | " . $purge_url );
 						        $this->_do_remote_get( $purge_url );
 						    }
 						}

--- a/redis-purger.php
+++ b/redis-purger.php
@@ -680,7 +680,8 @@ namespace rtCamp\WP\Nginx {
 			$purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?
 				explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
 			
-                        $purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls);
+                        // Allow plugins/themes to modify/extend urls. Pass urls array in first parameter, second says if wildcards are allowed
+                        $purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls, true);
                         
                         if( is_array( $purge_urls ) && ! empty( $purge_urls ) ) {
 				foreach ($purge_urls as $purge_url ) {

--- a/redis-purger.php
+++ b/redis-purger.php
@@ -665,47 +665,47 @@ namespace rtCamp\WP\Nginx {
 			$this->log( "* Purged Everything!" );
 			$this->log( "* * * * *" );
 			//delete_multi_keys("*");
-            		delete_keys_by_wildcard("*");
-        	}
-        
-        	function purge_urls()
+			delete_keys_by_wildcard("*");
+		}
+		
+		function purge_urls()
 		{
 			global $rt_wp_nginx_helper;
-            
-        		$parse = parse_url( site_url() );
+			
+			$parse = parse_url( site_url() );
 			$host = $rt_wp_nginx_helper->options['redis_hostname'];
 			$prefix = $rt_wp_nginx_helper->options['redis_prefix'];
 			$_url_purge_base = $prefix . $parse['scheme'] . 'GET' . $parse['host'];
 			
 			$purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?
-                		explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
+				explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
 			
                         $purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls);
                         
                         if( is_array( $purge_urls ) && ! empty( $purge_urls ) ) {
 				foreach ($purge_urls as $purge_url ) {
-				    $purge_url = trim( $purge_url );
-				
-				    if( strpos( $purge_url, '*' ) === false ) {
-				        $purge_url = $_url_purge_base . $purge_url;
-				        $status = delete_single_key( $purge_url );
-				        if( $status ) {
-				            $this->log( "- Purge URL | " . $purge_url );
-				        } else {
-				            $this->log( "- Not Found | " . $purge_url, 'ERROR' );
-				        }
-				    } else {
-				        $purge_url = $_url_purge_base . $purge_url;
-				        $status = delete_keys_by_wildcard( $purge_url );
-				        if( $status ) {
-				            $this->log( "- Purge Wild Card URL | " . $purge_url . " | ". $status . " url purged" );
-				        } else {
-				            $this->log( "- Not Found | " . $purge_url, 'ERROR' );
-				        }
-				    }
+					$purge_url = trim( $purge_url );
+					
+					if( strpos( $purge_url, '*' ) === false ) {
+						$purge_url = $_url_purge_base . $purge_url;
+						$status = delete_single_key( $purge_url );
+						if( $status ) {
+						    $this->log( "- Purge URL | " . $purge_url );
+						} else {
+						    $this->log( "- Not Found | " . $purge_url, 'ERROR' );
+						}
+					} else {
+						$purge_url = $_url_purge_base . $purge_url;
+						$status = delete_keys_by_wildcard( $purge_url );
+						if( $status ) {
+						    $this->log( "- Purge Wild Card URL | " . $purge_url . " | ". $status . " url purged" );
+						} else {
+						    $this->log( "- Not Found | " . $purge_url, 'ERROR' );
+						}
+					}
 				}
                         }
-        	}
-
+		}
+		
 	}
 }

--- a/redis-purger.php
+++ b/redis-purger.php
@@ -665,45 +665,47 @@ namespace rtCamp\WP\Nginx {
 			$this->log( "* Purged Everything!" );
 			$this->log( "* * * * *" );
 			//delete_multi_keys("*");
-            delete_keys_by_wildcard("*");
-        }
+            		delete_keys_by_wildcard("*");
+        	}
         
-        function purge_urls()
+        	function purge_urls()
 		{
 			global $rt_wp_nginx_helper;
             
-            $parse = parse_url( site_url() );
+        		$parse = parse_url( site_url() );
 			$host = $rt_wp_nginx_helper->options['redis_hostname'];
 			$prefix = $rt_wp_nginx_helper->options['redis_prefix'];
 			$_url_purge_base = $prefix . $parse['scheme'] . 'GET' . $parse['host'];
 			
-            if( isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ) {
-                $purge_urls = explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] );
-
-                foreach ($purge_urls as $purge_url ) {
-                    $purge_url = trim( $purge_url );
-
-                    if( strpos( $purge_url, '*' ) === false ) {
-                        $purge_url = $_url_purge_base . $purge_url;
-                        $status = delete_single_key( $purge_url );
-                        if( $status ) {
-                            $this->log( "- Purge URL | " . $purge_url );
-                        } else {
-                            $this->log( "- Not Found | " . $purge_url, 'ERROR' );
+			$purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?
+                		explode( "\r\n", $rt_wp_nginx_helper->options['purge_url'] ) : array();
+			
+                        $purge_urls = apply_filters('rt_nginx_helper_purge_urls', $purge_urls);
+                        
+                        if( is_array( $purge_urls ) && ! empty( $purge_urls ) ) {
+				foreach ($purge_urls as $purge_url ) {
+				    $purge_url = trim( $purge_url );
+				
+				    if( strpos( $purge_url, '*' ) === false ) {
+				        $purge_url = $_url_purge_base . $purge_url;
+				        $status = delete_single_key( $purge_url );
+				        if( $status ) {
+				            $this->log( "- Purge URL | " . $purge_url );
+				        } else {
+				            $this->log( "- Not Found | " . $purge_url, 'ERROR' );
+				        }
+				    } else {
+				        $purge_url = $_url_purge_base . $purge_url;
+				        $status = delete_keys_by_wildcard( $purge_url );
+				        if( $status ) {
+				            $this->log( "- Purge Wild Card URL | " . $purge_url . " | ". $status . " url purged" );
+				        } else {
+				            $this->log( "- Not Found | " . $purge_url, 'ERROR' );
+				        }
+				    }
+				}
                         }
-                    } else {
-                        $purge_url = $_url_purge_base . $purge_url;
-                        $status = delete_keys_by_wildcard( $purge_url );
-                        if( $status ) {
-                            $this->log( "- Purge Wild Card URL | " . $purge_url . " | ". $status . " url purged" );
-                        } else {
-                            $this->log( "- Not Found | " . $purge_url, 'ERROR' );
-                        }
-                    }
-                }
-            }
-        }
+        	}
 
 	}
-
 }


### PR DESCRIPTION
Hi all, for one of my plugins I needed a way to purge additional URLs along with normal page/post/taxonomy and feed URLs. The new option "Custom Purge URL" is useful but the URLs in my plugin can vary according to plugin settings which makes it too complicated for users to add them manually.

This hook allows the $purge_urls array to be altered or appended just before purging custom urls. The hook passes the array of custom urls and expects an array to be returned.

Note: I do not have a Redis server so only the changes to purger.php are tested. If anyone has a Redis server and time to test the changes, please let me know.