### PR TITLE
Don't add timestamp if cron or wpcli

### DIFF
--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -271,6 +271,10 @@ namespace rtCamp\WP\Nginx {
 
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX )
 				return;
+			if ( defined( 'DOING_CRON' ) && DOING_CRON )
+				return;
+			if ( defined( 'WP_CLI' ) && WP_CLI )
+				return;
 			$timestamps = "\n<!--" .
 					"Cached using Nginx-Helper on " . current_time( 'mysql' ) . ". " .
 					"It took " . get_num_queries() . " queries executed in " . timer_stop() . " seconds." .


### PR DESCRIPTION
Doesn't make sense to show HTML comments in places that aren't necessarily HTML output