### PR TITLE
Add WPML Support + Change in Purge ALL with Redis. 

### DIFF
--- a/purger.php
+++ b/purger.php
@@ -102,10 +102,7 @@ namespace rtCamp\WP\Nginx {
 			$this->log( "Function purgePost BEGIN ===" );
 
 			if ( $rt_wp_nginx_helper->options[ 'purge_homepage_on_edit' ] == 1 ) {
-				$homepage_url = trailingslashit( home_url() );
-
-				$this->log( "Purging homepage '$homepage_url'" );
-				$this->purgeUrl( $homepage_url );
+				$this->_purge_homepage(); 
 			}
 
 
@@ -435,10 +432,18 @@ namespace rtCamp\WP\Nginx {
 		}
 
 		private function _purge_homepage() {
+		    //  WPML installetd?
+			if ( function_exists('icl_get_home_url') )
+			{
+				$homepage_url = trailingslashit( icl_get_home_url() );
+				$this->log( sprintf( __( "Purging homepage (WPML) '%s'", "nginx-helper" ), $homepage_url ) );
+			}
+			else
+			{
+				$homepage_url = trailingslashit( home_url() );
+				$this->log( sprintf( __( "Purging homepage '%s'", "nginx-helper" ), $homepage_url ) );
+			}
 
-			$homepage_url = trailingslashit( home_url() );
-
-			$this->log( sprintf( __( "Purging homepage '%s'", "nginx-helper" ), $homepage_url ) );
 			$this->purgeUrl( $homepage_url );
 
 			return true;

--- a/redis-purger.php
+++ b/redis-purger.php
@@ -109,10 +109,8 @@ namespace rtCamp\WP\Nginx {
 			$this->log( "Function purgePost BEGIN ===" );
 
 			if ( $rt_wp_nginx_helper->options['purge_homepage_on_edit'] == 1 ) {
-				$homepage_url = trailingslashit( home_url() );
-
 				$this->log( "Purging homepage '$homepage_url'" );
-				$this->purgeUrl( $homepage_url );
+				$this->_purge_homepage();
 			}
 
 
@@ -329,10 +327,18 @@ namespace rtCamp\WP\Nginx {
 
 		private function _purge_homepage()
 		{
+			//  WPML installetd?
+			if ( function_exists('icl_get_home_url') )
+			{
+				$homepage_url = trailingslashit( icl_get_home_url() );
+				$this->log( sprintf( __( "Purging homepage (WPML) '%s'", "nginx-helper" ), $homepage_url ) );
+			}
+			else
+			{
+				$homepage_url = trailingslashit( home_url() );
+				$this->log( sprintf( __( "Purging homepage '%s'", "nginx-helper" ), $homepage_url ) );
+			}
 
-			$homepage_url = trailingslashit( home_url() );
-
-			$this->log( sprintf( __( "Purging homepage '%s'", "nginx-helper" ), $homepage_url ) );
 			$this->purgeUrl( $homepage_url );
 
 			return true;

--- a/redis-purger.php
+++ b/redis-purger.php
@@ -667,11 +667,12 @@ namespace rtCamp\WP\Nginx {
 		function true_purge_all()
 		{
 			global $rt_wp_nginx_helper;
+			$prefix = substr($rt_wp_nginx_helper->options['redis_prefix'],0, -1);
 			$this->log( "* * * * *" );
 			$this->log( "* Purged Everything!" );
 			$this->log( "* * * * *" );
 			//delete_multi_keys("*");
-			delete_keys_by_wildcard("*");
+			delete_keys_by_wildcard($prefix."*");
 		}
 		
 		function purge_urls()


### PR DESCRIPTION
Added WPML support following erich_k4wp solution: https://wordpress.org/support/topic/wrong-homepage-cache-cleared-when-wpml-plugin-used

And changed the purge all function for redis. For this issue [https://github.com/rtCamp/nginx-helper/issues/113](url)