### PR TITLE
Add feed purging to redis cache

### DIFF
--- a/redis-purger.php
+++ b/redis-purger.php
@@ -220,7 +220,19 @@ namespace rtCamp\WP\Nginx {
 			$prefix = $rt_wp_nginx_helper->options['redis_prefix'];
 			$_url_purge_base = $prefix . $parse['scheme'] . 'GET' . $parse['host'] . $parse['path'];
 			delete_single_key( $_url_purge_base );
-        }
+			
+			if ( $feed ) {
+				$feed_url = rtrim( $_url_purge_base, '/' ) . '/feed/';
+				$this->log( "- Purging URL | " . $feed_url );
+				delete_single_key( $feed_url );
+				
+				$this->log( "- Purging URL | " . $feed_url . 'atom/' );
+				delete_single_key( $feed_url . 'atom/' );
+				
+				$this->log( "- Purging URL | " . $feed_url . 'rdf/' );
+				delete_single_key( $feed_url . 'rdf/' );
+			}
+		}
 
 		function log( $msg, $level = 'INFO' )
 		{


### PR DESCRIPTION
For some reason it appears that the redis purger does not include purging feeds. This patch enables the same feed purging as exists for the fastCGI cache.

To make use of this purging, (especially if using easy engine) you may have to change your nginx config to allow caching feeds. In the stock configuration of the easy engine nginx configuration, feeds are not cached. On a popular site that can lead to a lot of unnecessary PHP processing.