### PR TITLE
avoid deleting nginx cache folders

### DIFF
--- a/purger.php
+++ b/purger.php
@@ -778,7 +778,7 @@ namespace rtCamp\WP\Nginx {
 				}
 
 				if ( ! @unlink( $dir . '/' . $obj ) ) {
-					$this->unlinkRecursive( $dir . '/' . $obj, true );
+					$this->unlinkRecursive( $dir . '/' . $obj, false );
 				}
 			}
 			


### PR DESCRIPTION
Only files are deleted to prevent nginx from failing to serve cache content