### PR TITLE
fix wp_redirect

### DIFF
--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -374,6 +374,8 @@ namespace {
 				$location = wp_sanitize_redirect( $location );
 			}
 			header( 'Location: ' . $location, true, $status );
+
+			return true;
 		}
 
 	}


### PR DESCRIPTION
wp_redirect should return true on success

The core WP function does this and it should for compatibility.
https://developer.wordpress.org/reference/functions/wp_redirect/

Uncovered in this issue with Redirection https://github.com/johngodley/redirection/issues/157

