### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ Most likely yes. A wordpress plugin, if not using explicitly any Apache-only mod
 Please post your problem in [our free support forum](http://community.rtcamp.com/c/wordpress-nginx).
 
 ## Screenshots ##
-###1. Nginx plugin settings###
+### 1. Nginx plugin settings ###
 ![Nginx plugin settings](https://ps.w.org/nginx-helper/assets/screenshot-1.png)
 
-###2. Remaining settings###
+### 2. Remaining settings ###
 ![Remaining settings](https://ps.w.org/nginx-helper/assets/screenshot-2.png)
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
