### PR TITLE
adding do_action after full cache purge

### DIFF
--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -311,6 +311,7 @@ namespace rtCamp\WP\Nginx {
 					$this->true_purge_all();
 					break;
 			}
+			do_action( 'rt_nginx_helper_cache_purged_all' );
 			wp_redirect( esc_url_raw( add_query_arg( array( 'nginx_helper_action' => 'done' ) ) ) );
 		}
 


### PR DESCRIPTION
goal: to allow other plugins to act upon full cache purges. example; to have Autoptimize clear it's cache when used in combination with nginx-helper and the latter's cache if cleared.