### PR TITLE
Fix several bugs

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -39,6 +39,7 @@ namespace rtCamp\WP\Nginx {
 				$rt_wp_nginx_helper_options = rt_wp_nginx_helper_get_options();
 				update_site_option( "rt_wp_nginx_helper_options", $rt_wp_nginx_helper_options );
 			}
+			$rt_wp_nginx_helper->update_map();
 		} else {
 			$rt_wp_nginx_helper_options = get_option( 'rt_wp_nginx_helper_options' );
 			if ( empty( $rt_wp_nginx_helper_options ) ) {

--- a/admin/install.php
+++ b/admin/install.php
@@ -34,13 +34,10 @@ namespace rtCamp\WP\Nginx {
 		}
 
 		if ( is_multisite() ) {
-			$blogs = get_blogs_of_user( true );
-			foreach ( $blogs as $b ) {
-				$rt_wp_nginx_helper_options = get_blog_option( $b->userblog_id, 'rt_wp_nginx_helper_options' );
-				if ( empty( $rt_wp_nginx_helper_options ) ) {
-					$rt_wp_nginx_helper_options = rt_wp_nginx_helper_get_options();
-					update_blog_option( $b->userblog_id, "rt_wp_nginx_helper_options", $rt_wp_nginx_helper_options );
-				}
+			$rt_wp_nginx_helper_options = get_site_option( 'rt_wp_nginx_helper_options', [] );
+			if ( empty( $rt_wp_nginx_helper_options ) ) {
+				$rt_wp_nginx_helper_options = rt_wp_nginx_helper_get_options();
+				update_site_option( "rt_wp_nginx_helper_options", $rt_wp_nginx_helper_options );
 			}
 		} else {
 			$rt_wp_nginx_helper_options = get_option( 'rt_wp_nginx_helper_options' );

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -51,7 +51,7 @@ namespace rtCamp\WP\Nginx {
 			add_action( 'shutdown', array( &$this, 'add_timestamps' ), 99999 );
 			add_action( 'add_init', array( &$this, 'update_map' ) );
 
-			//add_action( 'save_post', array( &$rt_wp_nginx_purger, 'purgePost' ), 200, 1 );
+			add_action( 'save_post', array( &$rt_wp_nginx_purger, 'purgePost' ), 200, 1 );
 			// add_action( 'publish_post', array( &$rt_wp_nginx_purger, 'purgePost' ), 200, 1 );
 			// add_action( 'publish_page', array( &$rt_wp_nginx_purger, 'purgePost' ), 200, 1 );
 			add_action( 'wp_insert_comment', array( &$rt_wp_nginx_purger, 'purgePostOnComment' ), 200, 2 );

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -69,7 +69,7 @@ namespace rtCamp\WP\Nginx {
 
 			add_action( 'transition_post_status', array( &$this, 'set_future_post_option_on_future_status' ), 20, 3 );
 			add_action( 'delete_post', array( &$this, 'unset_future_post_option_on_delete' ), 20, 1 );
-			add_action( 'nm_check_log_file_size_daily', array( &$rt_wp_nginx_purger, 'checkAndTruncateLogFile' ), 100, 1 );
+			add_action( 'rt_wp_nginx_helper_check_log_file_size_daily', array( &$rt_wp_nginx_purger, 'checkAndTruncateLogFile' ), 100, 1 );
 			add_action( 'edit_attachment', array( &$rt_wp_nginx_purger, 'purgeImageOnEdit' ), 100, 1 );
 			add_action( 'wpmu_new_blog', array( &$this, 'update_new_blog_options' ), 10, 1 );
 			add_action( 'transition_post_status', array( &$rt_wp_nginx_purger, 'purge_on_post_moved_to_trash' ), 20, 3 );

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -49,7 +49,6 @@ namespace rtCamp\WP\Nginx {
 
 			global $rt_wp_nginx_purger;
 			add_action( 'shutdown', array( &$this, 'add_timestamps' ), 99999 );
-			add_action( 'add_init', array( &$this, 'update_map' ) );
 
 			add_action( 'save_post', array( &$rt_wp_nginx_purger, 'purgePost' ), 200, 1 );
 			// add_action( 'publish_post', array( &$rt_wp_nginx_purger, 'purgePost' ), 200, 1 );
@@ -173,13 +172,8 @@ namespace rtCamp\WP\Nginx {
 		function update_new_blog_options( $blog_id )
 		{
 			global $rt_wp_nginx_purger;
-			include_once (RT_WP_NGINX_HELPER_PATH . 'admin/install.php');
-			$rt_wp_nginx_purger->log( "New site added (id $blog_id)" );
 			$this->update_map();
 			$rt_wp_nginx_purger->log( "New site added to nginx map (id $blog_id)" );
-			$helper_options = rt_wp_nginx_helper_get_options();
-			update_blog_option( $blog_id, "rt_wp_nginx_helper_options", $helper_options );
-			$rt_wp_nginx_purger->log( "Default options updated for the new blog (id $blog_id)" );
 		}
 
 		function get_map()


### PR DESCRIPTION
1.  fix install options for multisite
no need for single blog options as thy're not used anywhere on multisite, only **site_option** used
2. fix wrong cron job hook name
**nm_check_log_file_size_daily** -> **rt_wp_nginx_helper_check_log_file_size_daily**
3. uncomment **save_post** action
why it was commented out here? https://github.com/rtCamp/nginx-helper/commit/574c7eb4a93a330e8e8da65fdbde11682642f22d
4. remove unused single blog options, add **update_map** for multisite on plugin install
what is **add_init** action? it doesn't appear anywhere in WP or this plugin
5. remove unused future posts
future posts saved in **rt_wp_nginx_helper_global_options** but then never used anywhere, so what's the purpose?