### PR TITLE
Allow override Redis host/port/prefix via defines

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ To purge a page immediately, follow these instructions:
 * Needless to say, this won't work, if you have a page or taxonomy called 'purge'.
 
 
+### FAQ - Nginx Redis Cache ###
+
+**Q. Can I override the redis hostname, port and prefix?**
+
+Yes, you can force override the redis hostname, port or prefix by using defines. For example:
+
+`define('RT_WP_NGINX_HELPER_REDIS_HOSTNAME', '10.0.0.1');`
+`define('RT_WP_NGINX_HELPER_REDIS_PORT', '6000');`
+`define('RT_WP_NGINX_HELPER_REDIS_PREFIX', 'page-cache:');`
+
+
 ### FAQ - Nginx Map ###
 
 **Q. My multisite already uses `WPMU_ACCEL_REDIRECT`. Do I still need Nginx Map?**

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ To purge a page immediately, follow these instructions:
 Yes, you can force override the redis hostname, port or prefix by using defines. For example:
 
 `define('RT_WP_NGINX_HELPER_REDIS_HOSTNAME', '10.0.0.1');`
+
 `define('RT_WP_NGINX_HELPER_REDIS_PORT', '6000');`
+
 `define('RT_WP_NGINX_HELPER_REDIS_PREFIX', 'page-cache:');`
 
 

--- a/admin/lib/nginx-general.php
+++ b/admin/lib/nginx-general.php
@@ -186,21 +186,21 @@ namespace rtCamp\WP\Nginx {
 									<th><label for="redis_hostname"><?php _e( 'Hostname', 'nginx-helper' ); ?></label></th>
 									<td>
 										<input id="redis_hostname" class="medium-text" type="text" name="redis_hostname" value="<?php echo $redis_hostname; ?>" <?php echo $redis_hostname_readonly; ?> />
-                    <?php if ($redis_hostname_readonly) echo '<br>Overridden by global define'; ?>
+                    <?php if ($redis_hostname_readonly) echo '<p class="description">Overridden by global define</p>'; ?>
 									</td>
 								</tr>
 								<tr>
 									<th><label for="redis_port"><?php _e( 'Port', 'nginx-helper' ); ?></label></th>
 									<td>
 										<input id="redis_port" class="medium-text" type="text" name="redis_port" value="<?php echo $redis_port; ?>" <?php echo $redis_port_readonly; ?> />
-                    <?php if ($redis_port_readonly) echo '<br>Overridden by global define'; ?>
+                    <?php if ($redis_port_readonly) echo '<p class="description">Overridden by global define</p>'; ?>
 									</td>
 								</tr>
 								<tr>
 									<th><label for="redis_prefix"><?php _e( 'Prefix', 'nginx-helper' ); ?></label></th>
 									<td>
 										<input id="redis_prefix" class="medium-text" type="text" name="redis_prefix" value="<?php echo $redis_prefix; ?>" <?php echo $redis_prefix_readonly; ?> />
-                    <?php if ($redis_prefix_readonly) echo '<br>Overridden by global define'; ?>
+                    <?php if ($redis_prefix_readonly) echo '<p class="description">Overridden by global define</p>'; ?>
 									</td>
 								</tr>
 							</table>

--- a/admin/lib/nginx-general.php
+++ b/admin/lib/nginx-general.php
@@ -173,23 +173,34 @@ namespace rtCamp\WP\Nginx {
 								$redis_hostname = ( empty( $rt_wp_nginx_helper->options['redis_hostname'] ) ) ? '127.0.0.1' : $rt_wp_nginx_helper->options['redis_hostname'];
 								$redis_port = ( empty( $rt_wp_nginx_helper->options['redis_port'] ) ) ? '6379' : $rt_wp_nginx_helper->options['redis_port'];
 								$redis_prefix = ( empty( $rt_wp_nginx_helper->options['redis_prefix'] ) ) ? 'nginx-cache:' : $rt_wp_nginx_helper->options['redis_prefix'];
+
+                $redis_hostname = defined('RT_WP_NGINX_HELPER_REDIS_HOSTNAME') ? RT_WP_NGINX_HELPER_REDIS_HOSTNAME : $redis_hostname;
+                $redis_port = defined('RT_WP_NGINX_HELPER_REDIS_PORT') ? RT_WP_NGINX_HELPER_REDIS_PORT : $redis_port;
+                $redis_prefix = defined('RT_WP_NGINX_HELPER_REDIS_PREFIX') ? RT_WP_NGINX_HELPER_REDIS_PREFIX : $redis_prefix;
+
+                $redis_hostname_readonly = defined('RT_WP_NGINX_HELPER_REDIS_HOSTNAME') ? 'readonly="readonly"' : '';
+                $redis_port_readonly = defined('RT_WP_NGINX_HELPER_REDIS_PORT') ? 'readonly="readonly"' : '';
+                $redis_prefix_readonly = defined('RT_WP_NGINX_HELPER_REDIS_PREFIX') ? 'readonly="readonly"' : '';
 								?>
 								<tr>
 									<th><label for="redis_hostname"><?php _e( 'Hostname', 'nginx-helper' ); ?></label></th>
 									<td>
-										<input id="redis_hostname" class="medium-text" type="text" name="redis_hostname" value="<?php echo $redis_hostname; ?>" />
+										<input id="redis_hostname" class="medium-text" type="text" name="redis_hostname" value="<?php echo $redis_hostname; ?>" <?php echo $redis_hostname_readonly; ?> />
+                    <?php if ($redis_hostname_readonly) echo '<br>Overridden by global define'; ?>
 									</td>
 								</tr>
 								<tr>
 									<th><label for="redis_port"><?php _e( 'Port', 'nginx-helper' ); ?></label></th>
 									<td>
-										<input id="redis_port" class="medium-text" type="text" name="redis_port" value="<?php echo $redis_port; ?>" />
+										<input id="redis_port" class="medium-text" type="text" name="redis_port" value="<?php echo $redis_port; ?>" <?php echo $redis_port_readonly; ?> />
+                    <?php if ($redis_port_readonly) echo '<br>Overridden by global define'; ?>
 									</td>
 								</tr>
 								<tr>
 									<th><label for="redis_prefix"><?php _e( 'Prefix', 'nginx-helper' ); ?></label></th>
 									<td>
-										<input id="redis_prefix" class="medium-text" type="text" name="redis_prefix" value="<?php echo $redis_prefix; ?>" />
+										<input id="redis_prefix" class="medium-text" type="text" name="redis_prefix" value="<?php echo $redis_prefix; ?>" <?php echo $redis_prefix_readonly; ?> />
+                    <?php if ($redis_prefix_readonly) echo '<br>Overridden by global define'; ?>
 									</td>
 								</tr>
 							</table>

--- a/includes/redis-delete.php
+++ b/includes/redis-delete.php
@@ -5,8 +5,8 @@
 
 global $myredis, $rt_wp_nginx_helper, $redis_api, $lua, $rt_wp_nginx_purger;
 
-$host = $rt_wp_nginx_helper->options['redis_hostname'];
-$port = $rt_wp_nginx_helper->options['redis_port'];
+$host = defined('RT_WP_NGINX_HELPER_REDIS_HOSTNAME') ? RT_WP_NGINX_HELPER_REDIS_HOSTNAME : $rt_wp_nginx_helper->options['redis_hostname'];
+$port = defined('RT_WP_NGINX_HELPER_REDIS_PORT') ? RT_WP_NGINX_HELPER_REDIS_PORT : $rt_wp_nginx_helper->options['redis_port'];
 $redis_api = '';
 
 if ( class_exists( 'Redis' ) ) { // Use PHP5-Redis if installed.

--- a/redis-purger.php
+++ b/redis-purger.php
@@ -220,9 +220,9 @@ namespace rtCamp\WP\Nginx {
 				$parse['path'] = '';
 			}
 
-			$host = $rt_wp_nginx_helper->options['redis_hostname'];
+            $host = defined('RT_WP_NGINX_HELPER_REDIS_HOSTNAME') ? RT_WP_NGINX_HELPER_REDIS_HOSTNAME : $rt_wp_nginx_helper->options['redis_hostname'];
 
-			$prefix = $rt_wp_nginx_helper->options['redis_prefix'];
+            $prefix = defined('RT_WP_NGINX_HELPER_REDIS_PREFIX') ? RT_WP_NGINX_HELPER_REDIS_PREFIX : $rt_wp_nginx_helper->options['redis_prefix'];
 
 			$_url_purge_base = $prefix . $parse['scheme'] . 'GET' . $parse['host'] . $parse['path'];
 
@@ -675,7 +675,8 @@ namespace rtCamp\WP\Nginx {
 		function true_purge_all()
 		{
 			global $rt_wp_nginx_helper;
-			$prefix = trim( $rt_wp_nginx_helper->options['redis_prefix'] );
+            $prefix = defined('RT_WP_NGINX_HELPER_REDIS_PREFIX') ? RT_WP_NGINX_HELPER_REDIS_PREFIX : $rt_wp_nginx_helper->options['redis_prefix'];
+			$prefix = trim( $prefix );
 			
 			$this->log( '* * * * *' );
 			
@@ -698,8 +699,8 @@ namespace rtCamp\WP\Nginx {
 			global $rt_wp_nginx_helper;
 			
 			$parse = parse_url( site_url() );
-			$host = $rt_wp_nginx_helper->options['redis_hostname'];
-			$prefix = $rt_wp_nginx_helper->options['redis_prefix'];
+            $host = defined('RT_WP_NGINX_HELPER_REDIS_HOSTNAME') ? RT_WP_NGINX_HELPER_REDIS_HOSTNAME : $rt_wp_nginx_helper->options['redis_hostname'];
+            $prefix = defined('RT_WP_NGINX_HELPER_REDIS_PREFIX') ? RT_WP_NGINX_HELPER_REDIS_PREFIX : $rt_wp_nginx_helper->options['redis_prefix'];
 			$_url_purge_base = $prefix . $parse['scheme'] . 'GET' . $parse['host'];
 			
 			$purge_urls = isset( $rt_wp_nginx_helper->options['purge_url'] ) && ! empty( $rt_wp_nginx_helper->options['purge_url'] ) ?


### PR DESCRIPTION
The goal is to allow defining Redis cache's host/port/prefix without using nginx helper's settings backend page. The three defines are:

```
RT_WP_NGINX_HELPER_REDIS_HOSTNAME
RT_WP_NGINX_HELPER_REDIS_PORT
RT_WP_NGINX_HELPER_REDIS_PREFIX
```

If not defined, everything works as is (fallback to the settings stored in options, if empty, fallback to 127.0.0.1/6379/nginx-cache:

If defined, the input fields for the predefined redis settings are disabled, with note underneath to inform the user this field is overridden by defines.

Documentation (FAQ in README.md) is updated to reflect this feature.

The main benefit of this is in multiple server situations (production vs staging, load balanced servers, etc) you don't have to rely on database to inform nginx helper about where to find the redis server.

Thanks and please consider this PR.