### PR TITLE
🐛 Set default value for undefined variable

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -262,6 +262,7 @@ class Nginx_Helper_Admin {
 			'redis_port'                       => '6379',
 			'redis_prefix'                     => 'nginx-cache:',
 			'purge_url'                        => '',
+			'redis_enabled_by_constant'        => 0,
 		);
 
 	}


### PR DESCRIPTION
There is an undefined error when we install the plugin for the first time and if Redis is not available.