### PR TITLE
👌 Use network_admin_url to get network correct settings url

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -316,7 +316,7 @@ class Nginx_Helper_Admin {
 			$setting_page = 'options-general.php';
 		}
 
-		$settings_link = '<a href="' . admin_url( $setting_page . '?page=nginx' ) . '">' . __( 'Settings', 'nginx-helper' ) . '</a>';
+		$settings_link = '<a href="' . network_admin_url( $setting_page . '?page=nginx' ) . '">' . __( 'Settings', 'nginx-helper' ) . '</a>';
 		array_unshift( $links, $settings_link );
 
 		return $links;


### PR DESCRIPTION
On a multisite, using `admin_url` will link to main site's admin page. Use `network_admin_url` so it will link to network admin on a multisite, and on a single site it will link to normal admin page.