### PR TITLE
Support own actions at fcgi purge all

### DIFF
--- a/admin/class-fastcgi-purger.php
+++ b/admin/class-fastcgi-purger.php
@@ -18,6 +18,13 @@
  */
 class FastCGI_Purger extends Purger {
 
+	/*
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action('nginx_helper_fcgi_purge_all', array($this, 'unlink_recursive'), 10, 2);
+	}
+	
 	/**
 	 * Function to purge url.
 	 *
@@ -160,8 +167,7 @@ class FastCGI_Purger extends Purger {
 	 * Purge everything.
 	 */
 	public function purge_all() {
-
-		$this->unlink_recursive( RT_WP_NGINX_HELPER_CACHE_PATH, false );
+		do_action('nginx_helper_fcgi_purge_all', RT_WP_NGINX_HELPER_CACHE_PATH, false);
 		$this->log( '* * * * *' );
 		$this->log( '* Purged Everything!' );
 		$this->log( '* * * * *' );


### PR DESCRIPTION
In shared hosting environments, nginx runs at another system user (usually www-data) as PHP-FPM does. This means nginx writes its cache-files with owner www-data, and therefore fcgi cache purging fails because of missing write access.

In order to fix this I would suggest a new action. Using this action, anybody with other configs can just hook into this action and implement an own mechanism to purge all caching files.