### PR TITLE
Plugged locations that were sending purge requests even if disabled

### DIFF
--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -519,6 +519,13 @@ abstract class Purger {
 	 */
 	public function purge_image_on_edit( $attachment_id ) {
 
+		// Do not purge if not enabled.
+		global $nginx_helper_admin;
+
+		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+			return;
+		}
+		
 		$this->log( 'Purging media on edit BEGIN ===' );
 
 		if ( wp_attachment_is_image( $attachment_id ) ) {
@@ -1076,6 +1083,12 @@ abstract class Purger {
 	 */
 	public function purge_on_term_taxonomy_edited( $term_id, $tt_id, $taxon ) {
 
+		global $nginx_helper_admin;
+
+		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+			return;
+		}
+		
 		$this->log( __( 'Term taxonomy edited or deleted', 'nginx-helper' ) );
 
 		$term           = get_term( $term_id, $taxon );
@@ -1106,6 +1119,12 @@ abstract class Purger {
 	 */
 	public function purge_on_check_ajax_referer( $action ) {
 
+		global $nginx_helper_admin;
+
+		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+			return;
+		}
+		
 		switch ( $action ) {
 
 			case 'save-sidebar-widgets':


### PR DESCRIPTION
There are a few locations in nginx-helper (dating back to at least 1.9.10) that were sending requests to `/purge/` even if cache purging was disabled in settings. On our environment, this was causing errors and unnecessary load on our infrastructure. My patch simply adds guard conditions to `Purger::purge_image_on_edit`, `Purger::purge_on_taxonomy_term_edited`, and `Purger::purge_on_check_ajax_referer`.