### PR TITLE
Fix Purge Cache menu caching issue in the front-end

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -655,7 +655,7 @@ class Nginx_Helper_Admin {
 	 */
 	public function purge_all() {
 
-		global $nginx_purger;
+		global $nginx_purger, $wp;
 
 		$method = filter_input( INPUT_SERVER, 'REQUEST_METHOD', FILTER_SANITIZE_STRING );
 
@@ -682,13 +682,26 @@ class Nginx_Helper_Admin {
 		}
 
 		check_admin_referer( 'nginx_helper-purge_all' );
+
+		$current_url = esc_url_raw( user_trailingslashit( home_url( $wp->request ) ) );
+
+		if ( ! is_admin() ) {
+			$action       = 'purge_single_page';
+			$redirect_url = $current_url;
+		} else {
+			$redirect_url = add_query_arg( array( 'nginx_helper_action' => 'done' ) );
+		}
+
 		switch ( $action ) {
 			case 'purge':
 				$nginx_purger->purge_all();
 				break;
+			case 'purge_single_page':
+				$nginx_purger->purge_url( $current_url );
+				break;
 		}
 
-		wp_redirect( esc_url_raw( add_query_arg( array( 'nginx_helper_action' => 'done' ) ) ) );
+		wp_redirect( esc_url_raw( $redirect_url ) );
 		exit();
 
 	}

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -650,6 +650,8 @@ class Nginx_Helper_Admin {
 
 	/**
 	 * Purge all urls.
+	 * Purge current page cache when purging is requested from front
+	 * and all urls when requested from admin dashboard.
 	 *
 	 * @global object $nginx_purger
 	 */

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -201,10 +201,18 @@ class Nginx_Helper_Admin {
 			return;
 		}
 
+		if ( is_admin() ) {
+			$nginx_helper_urls = 'all';
+			$link_title        = __( 'Purge Cache', 'nginx-helper' );
+		} else {
+			$nginx_helper_urls = 'current-url';
+			$link_title        = __( 'Purge Current Page', 'nginx-helper' );
+		}
+
 		$purge_url  = add_query_arg(
 			array(
 				'nginx_helper_action' => 'purge',
-				'nginx_helper_urls'   => 'all',
+				'nginx_helper_urls'   => $nginx_helper_urls,
 			)
 		);
 
@@ -213,9 +221,9 @@ class Nginx_Helper_Admin {
 		$wp_admin_bar->add_menu(
 			array(
 				'id'    => 'nginx-helper-purge-all',
-				'title' => __( 'Purge Cache', 'nginx-helper' ),
+				'title' => $link_title,
 				'href'  => $nonced_url,
-				'meta'  => array( 'title' => __( 'Purge Cache', 'nginx-helper' ) ),
+				'meta'  => array( 'title' => array( 'title' => $link_title ) ),
 			)
 		);
 

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -223,7 +223,7 @@ class Nginx_Helper_Admin {
 				'id'    => 'nginx-helper-purge-all',
 				'title' => $link_title,
 				'href'  => $nonced_url,
-				'meta'  => array( 'title' => array( 'title' => $link_title ) ),
+				'meta'  => array( 'title' => $link_title ),
 			)
 		);
 
@@ -685,7 +685,7 @@ class Nginx_Helper_Admin {
 
 		check_admin_referer( 'nginx_helper-purge_all' );
 
-		$current_url = esc_url_raw( user_trailingslashit( home_url( $wp->request ) ) );
+		$current_url = user_trailingslashit( home_url( $wp->request ) );
 
 		if ( ! is_admin() ) {
 			$action       = 'purge_current_page';

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -688,7 +688,7 @@ class Nginx_Helper_Admin {
 		$current_url = esc_url_raw( user_trailingslashit( home_url( $wp->request ) ) );
 
 		if ( ! is_admin() ) {
-			$action       = 'purge_single_page';
+			$action       = 'purge_current_page';
 			$redirect_url = $current_url;
 		} else {
 			$redirect_url = add_query_arg( array( 'nginx_helper_action' => 'done' ) );
@@ -698,7 +698,7 @@ class Nginx_Helper_Admin {
 			case 'purge':
 				$nginx_purger->purge_all();
 				break;
-			case 'purge_single_page':
+			case 'purge_current_page':
 				$nginx_purger->purge_url( $current_url );
 				break;
 		}

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -221,7 +221,7 @@ class Nginx_Helper {
 		$this->loader->add_action( 'edit_term', $nginx_purger, 'purge_on_term_taxonomy_edited', 20, 3 );
 		$this->loader->add_action( 'delete_term', $nginx_purger, 'purge_on_term_taxonomy_edited', 20, 3 );
 		$this->loader->add_action( 'check_ajax_referer', $nginx_purger, 'purge_on_check_ajax_referer', 20 );
-		$this->loader->add_action( 'admin_init', $nginx_helper_admin, 'purge_all' );
+		$this->loader->add_action( 'admin_bar_init', $nginx_helper_admin, 'purge_all' );
 
 		// expose action to allow other plugins to purge the cache.
 		$this->loader->add_action( 'rt_nginx_helper_purge_all', $nginx_purger, 'purge_all' );


### PR DESCRIPTION
I have fixed the Purge Cache menu caching issue in front-end.
I have changed the name of Purge Cache menu button in the front to 'Purge Current Page'
When the 'Purge Current Page' menu button on the front end is now clicked, it only clears the page cache.

Fixes #171