### PR TITLE
Added a typecast for check on purge_page_on_new_comment option for ne…

### DIFF
--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -96,7 +96,7 @@ abstract class Purger {
 		switch ( $newstatus ) {
 
 			case 'approved':
-				if ( 1 === $nginx_helper_admin->options['purge_page_on_new_comment'] ) {
+				if ( 1 === (int)$nginx_helper_admin->options['purge_page_on_new_comment'] ) {
 
 					$this->log( '* Comment ( ' . $_comment_id . ' ) approved. Post ( ' . $_post_id . ' ) purging...' );
 					$this->log( '* * * * *' );


### PR DESCRIPTION
New comments were not purging the post.

Using === for equality comparisons require both operands to be of the same type. Other instances of this and similar checks of integer-type options have the appropriate cast. Missing it here means new comments will not purge the post properly.