### PR TITLE
Purge Cache menu only on admin

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -197,7 +197,7 @@ class Nginx_Helper_Admin {
 	 */
 	public function nginx_helper_toolbar_purge_link( $wp_admin_bar ) {
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Remove it from front end admin bar where it does nothing because Nginx_Helper_Admin->purge_all() is only called on admin_init...