### PR TITLE
Prevent double purge on post

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -563,7 +563,7 @@ class Nginx_Helper_Admin {
 
 		global $blog_id, $nginx_purger;
 
-		if ( ! $this->options['enable_purge'] ) {
+		if ( ! $this->options['enable_purge'] || $old_status === $new_status ) {
 			return;
 		}
 


### PR DESCRIPTION
Sometime update post status hook may run twice. See https://wordpress.org/support/topic/purge-on-publish-sometimes-runs-twice/