### PR TITLE
Attempt log file creation if parent directory is writable

### DIFF
--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -647,7 +647,7 @@ if ( is_network_admin() ) {
 			if ( ! is_dir( $log_path ) ) {
 				mkdir( $log_path );
 			}
-			if ( ! file_exists( $log_path . 'nginx.log' ) ) {
+			if ( is_writable( $log_path ) && ! file_exists( $log_path . 'nginx.log' ) ) {
 				$log = fopen( $log_path . 'nginx.log', 'w' );
 				fclose( $log );
 			}


### PR DESCRIPTION
PHP throws a warning at fopen line that it failed to open log file. This
happens when program tries to create a file but parent directory is not
writable.

This commit adds that check before attempting creation of a file