### PR TITLE
Correct the links for fastcgi cache purge

### DIFF
--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -77,12 +77,12 @@ $log_url               = $nginx_helper_admin->functional_asset_url();
 $nginx_setting_link = '#';
 if ( is_multisite() ) {
 	if ( SUBDOMAIN_INSTALL === false ) {
-		$nginx_setting_link = 'https://rtcamp.com/wordpress-nginx/tutorials/multisite/subdirectories/fastcgi-cache-with-purging/';
+		$nginx_setting_link = 'https://easyengine.io/wordpress-nginx/tutorials/multisite/subdirectories/fastcgi-cache-with-purging/';
 	} else {
-		$nginx_setting_link = 'https://rtcamp.com/wordpress-nginx/tutorials/multisite/subdomains/fastcgi-cache-with-purging/';
+		$nginx_setting_link = 'https://easyengine.io/wordpress-nginx/tutorials/multisite/subdomains/fastcgi-cache-with-purging/';
 	}
 } else {
-	$nginx_setting_link = 'https://rtcamp.com/wordpress-nginx/tutorials/single-site/fastcgi-cache-with-purging/';
+	$nginx_setting_link = 'https://easyengine.io/wordpress-nginx/tutorials/single-site/fastcgi-cache-with-purging/';
 }
 ?>
 


### PR DESCRIPTION
The existing links were going into infinite redirect loop, and not showing the article that its intended to do.