### PR TITLE
Add option to deploy plugin to WP.org using GitHub Actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -15,6 +15,6 @@ action "WordPress Plugin Deploy" {
   secrets = ["WORDPRESS_USERNAME", "WORDPRESS_PASSWORD"]
   env = {
     SLUG = "nginx-helper"
-    EXCLUDE_LIST = ".gitattributes .gitignore .travis.yml README.md deploy.sh"
+    EXCLUDE_LIST = ".gitattributes .gitignore .travis.yml README.md deploy.sh readme.sh tests map.conf nginx.log"
   }
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -11,10 +11,10 @@ action "tag" {
 
 action "WordPress Plugin Deploy" {
   needs = ["tag"]
-  uses = "rtcamp/github-actions-library/wp-plugin-deploy@master"
+  uses = "rtCamp/action-wp-org-plugin-deploy@master"
   secrets = ["WORDPRESS_USERNAME", "WORDPRESS_PASSWORD"]
   env = {
     SLUG = "nginx-helper"
-    EXCLUDE_LIST = ".gitattributes .gitignore .travis.yml README.md deploy.sh readme.sh tests map.conf nginx.log"
+    EXCLUDE_LIST = ".gitattributes .gitignore .travis.yml README.md deploy.sh readme.sh tests map.conf nginx.log wercker.yml"
   }
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,20 @@
+workflow "Deploy" {
+  resolves = ["WordPress Plugin Deploy"]
+  on = "push"
+}
+
+# Filter for tag
+action "tag" {
+    uses = "actions/bin/filter@master"
+    args = "tag"
+}
+
+action "WordPress Plugin Deploy" {
+  needs = ["tag"]
+  uses = "rtcamp/github-actions-library/wp-plugin-deploy@master"
+  secrets = ["WORDPRESS_USERNAME", "WORDPRESS_PASSWORD"]
+  env = {
+    SLUG = "nginx-helper"
+    EXCLUDE_LIST = ".gitattributes .gitignore .travis.yml README.md deploy.sh"
+  }
+}


### PR DESCRIPTION
Use GitHub action to release plugin. 

Ref: https://github.com/rtCamp/action-wp-org-plugin-deploy

When you are tagging the release please don't add `v` along with version_number.

`git tag -a 2.0.3 -m "Tagging Version 2.0.3"`
