### PR TITLE
Fix an error when the uploads directory is located in a non-default location.

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -340,7 +340,7 @@ class Nginx_Helper_Admin {
 	 */
 	public function functional_asset_path() {
 
-		$log_path = WP_CONTENT_DIR . '/uploads/nginx-helper/';
+		$log_path = wp_upload_dir()['path'] . '/nginx-helper/';
 
 		return apply_filters( 'nginx_asset_path', $log_path );
 
@@ -354,7 +354,7 @@ class Nginx_Helper_Admin {
 	 */
 	public function functional_asset_url() {
 
-		$log_url = WP_CONTENT_URL . '/uploads/nginx-helper/';
+		$log_url = wp_upload_dir()['url'] . '/nginx-helper/';
 
 		return apply_filters( 'nginx_asset_url', $log_url );
 


### PR DESCRIPTION
Per codex.wordpress.org, ["[The WP_CONTENT_DIR and WP_CONTENT_URL constants] should not be used directly by plugins or themes."](https://codex.wordpress.org/Determining_Plugin_and_Content_Directories#Constants)