### PR TITLE
Don't try to check the size of nginx.log if it doesn't exist

### DIFF
--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -559,7 +559,15 @@ abstract class Purger {
 
 		global $nginx_helper_admin;
 
+		if ( ! $nginx_helper_admin->options['enable_log'] ) {
+			return;
+		}
+
 		$nginx_asset_path = $nginx_helper_admin->functional_asset_path() . 'nginx.log';
+
+		if ( ! file_exists($nginx_asset_path) ) {
+			return;
+		}
 
 		$max_size_allowed = ( is_numeric( $nginx_helper_admin->options['log_filesize'] ) ) ? $nginx_helper_admin->options['log_filesize'] * 1048576 : 5242880;
 


### PR DESCRIPTION
If logging has never been enabled, the `nginx.log` won't exist and `filesize()` will throw an exception.