### PR TITLE
new filter to give to the user more information about purge object

### DIFF
--- a/admin/class-phpredis-purger.php
+++ b/admin/class-phpredis-purger.php
@@ -120,6 +120,9 @@ class PhpRedis_Purger extends Purger {
 
 		$prefix          = $nginx_helper_admin->options['redis_prefix'];
 		$_url_purge_base = $prefix . $parse['scheme'] . 'GET' . $parse['host'] . $parse['path'];
+		if( array_key_exists( 'query', $parse ) ):
+			$_url_purge_base .=  '?' . $parse['query'];
+		endif;
 		$is_purged       = $this->delete_single_key( $_url_purge_base );
 
 		if ( $is_purged ) {

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -119,6 +119,9 @@ class Predis_Purger extends Purger {
 
 		$prefix          = $nginx_helper_admin->options['redis_prefix'];
 		$_url_purge_base = $prefix . $parse['scheme'] . 'GET' . $parse['host'] . $parse['path'];
+		if( array_key_exists( 'query', $parse ) ):
+			$_url_purge_base .=  '?' . $parse['query'];
+		endif;
 		$this->delete_single_key( $_url_purge_base );
 
 	}

--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -356,6 +356,15 @@ abstract class Purger {
 				}
 			}
 		}
+
+		$additional_urls = array();
+		$additional_urls = apply_filters( 'rt_nginx_helper_additional_purge_urls', $post_id, $blog_id, $_purge_page, $_purge_archive, $_purge_custom_taxa );
+		if( ! empty( $additional_urls ) ):
+			foreach( $additional_urls as $url ):
+				$this->log( 'Purging additional URLs ' );
+				$this->purge_url( $url );
+			endforeach;
+		endif;
 	}
 
 	/**


### PR DESCRIPTION
Hi Guys!

First of all i would like to say thx because you all are doing an amazing job here! 

i have a lot of urls with a different behavior/style based on its query strings; example:

http://example.com/some-nice-news/
http://example.com/some-nice-news/?amp   <- this is an amp version of the news

i have to make cache of this link too (?amp) so i have added some filter at the end of the function _purge_by_options to accomplish this because i dont have this power at any moment in the code like having the purge object at my hand to add some logic to purge some things based on this information.

and i have made some small change on function purge_url to not ignore my query string if it exist.
