### PR TITLE
Changed variable for 'Custom Purge URL' field value

### DIFF
--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -496,7 +496,7 @@ if ( is_multisite() ) {
 							<h4><?php esc_html_e( 'Custom Purge URL:', 'nginx-helper' ); ?></h4>
 						</th>
 						<td>
-							<textarea rows="5"class="rt-purge_url" id="purge_url" name="purge_url"><?php echo esc_textarea( $nginx_helper_admin->options['purge_url'] ); ?></textarea>
+							<textarea rows="5"class="rt-purge_url" id="purge_url" name="purge_url"><?php echo esc_textarea( $nginx_helper_settings['purge_url'] ); ?></textarea>
 							<p class="description">
 								<?php
 								esc_html_e( 'Add one URL per line. URL should not contain domain name.', 'nginx-helper' );


### PR DESCRIPTION
This PR fixes #240 issue

The issue was in array from which we recieve "purge_url" value. It was `$nginx_helper_admin->options` which store previous values. I've changed it to `nginx_helper_settings` which is used for all other fields.