### PR TITLE
Fix PHP Notice:  Undefined index: path

### DIFF
--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -387,7 +387,8 @@ abstract class Purger {
 		}
 
 		// Build a hash of the URL.
-		$hash = md5( $url_data['scheme'] . 'GET' . $url_data['host'] . $url_data['path'] );
+		$url_path = isset( $url_data['path'] ) ? $url_data['path'] : '';
+		$hash = md5( $url_data['scheme'] . 'GET' . $url_data['host'] . $url_path );
 
 		// Ensure trailing slash.
 		$cache_path = RT_WP_NGINX_HELPER_CACHE_PATH;


### PR DESCRIPTION
Fixes #190 & #251

Check if `$url_data['path']` is defined to fix notices thrown when invalidating the home page

> PHP Notice:  Undefined index: path in /wp-content/plugins/nginx-helper/admin/class-purger.php on line 390