### PR TITLE
Fix: ignore purging on update of every nav_menu_item

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -577,6 +577,12 @@ class Nginx_Helper_Admin {
 
 		global $blog_id, $nginx_purger;
 
+		$exclude_post_types = array( 'nav_menu_item' );
+
+		if ( in_array( $post->post_type, $exclude_post_types, true ) ) {
+			return;
+		}
+
 		if ( ! $this->options['enable_purge'] ) {
 			return;
 		}


### PR DESCRIPTION
Do not need to purge the homepage, date archive, author archive, category archive on the update of each menu item. Purging those URLs on each menu item update will cause performance issues and overhead. So, this PR will ignore purging on `nav_menu_item`.

See #112