### PR TITLE
Purge All cache if menu is associated with any location else ignore

### DIFF
--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -1161,6 +1161,10 @@ abstract class Purger {
 
 		global $nginx_helper_admin;
 
+		if ( $taxon === 'nav_menu' ) {
+			return;
+		}
+
 		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
 			return;
 		}

--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -1218,6 +1218,32 @@ abstract class Purger {
 	}
 
 	/**
+	 * Purge All on Nav Menu Update.
+	 * Only if the menu is associated with any display location.
+	 *
+	 * @param int $menu_id Menu ID
+	 *
+	 * @return void
+	 */
+	public function purge_on_nav_menu_update( $menu_id ) {
+
+		global $nginx_helper_admin;
+
+		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+			return;
+		}
+
+		$this->log( sprintf( __( 'Menu updated. Menu ID: %s', 'nginx-helper' ), $menu_id ) );
+
+		$menu_locations = get_nav_menu_locations();
+
+		if ( in_array( $menu_id, $menu_locations, true ) ) {
+
+			$this->purge_all();
+		}
+	}
+
+	/**
 	 * Unlink file recursively.
 	 * Source - http://stackoverflow.com/a/1360437/156336
 	 *

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -223,6 +223,7 @@ class Nginx_Helper {
 		$this->loader->add_action( 'edit_term', $nginx_purger, 'purge_on_term_taxonomy_edited', 20, 3 );
 		$this->loader->add_action( 'delete_term', $nginx_purger, 'purge_on_term_taxonomy_edited', 20, 3 );
 		$this->loader->add_action( 'check_ajax_referer', $nginx_purger, 'purge_on_check_ajax_referer', 20 );
+		$this->loader->add_action( 'wp_update_nav_menu', $nginx_purger, 'purge_on_nav_menu_update', 20 );
 		$this->loader->add_action( 'admin_bar_init', $nginx_helper_admin, 'purge_all' );
 
 		// expose action to allow other plugins to purge the cache.


### PR DESCRIPTION
[New: Purge All on Nav Menu Update, only if the menu is associated with any display location](https://github.com/rtCamp/nginx-helper/commit/376db90a8848b6d84a1e147c895f02ee868111f7)

[Stop purging homepage on menu update as menu update will trigger purge all or ignore separately](https://github.com/rtCamp/nginx-helper/commit/93bc14694415fe738ec34bf0946c0ef1b1e8f434) 