### PR TITLE
Cache post page upon getting published and Preload URLs on shutdown hook

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -740,7 +740,77 @@ class Nginx_Helper_Admin {
 	}
 
 	/**
-	 * Dispay plugin notices.
+	 * Cache new post upon getting published.
+	 *
+	 * @since 2.2.3
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return void
+	 */
+	public function preload_new_published_post( $new_status, $old_status, $post ) {
+
+		if ( ! $this->options['enable_purge'] ) {
+			return;
+		}
+
+		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
+
+			$post_url = get_permalink( $post );
+
+			add_filter( 'rt_nginx_helper_preload_urls', function ( $urls ) use ( $post_url ) {
+				$urls[] = $post_url;
+				return $urls;
+			} );
+		}
+
+	}
+
+	/**
+	 * Preload cache of URLs.
+	 *
+	 * @since 2.2.3
+	 *
+	 * @return void
+	 */
+	public function preload_urls() {
+
+		global $nginx_purger;
+
+		if ( ! $this->options['enable_purge'] ) {
+			return;
+		}
+
+		/**
+		 * Filters the preload urls.
+		 *
+		 * @since 2.2.3
+		 *
+		 * @param array $urls URLs, which will be preloaded.
+		 */
+		$urls = apply_filters( "rt_nginx_helper_preload_urls", array() );
+
+		if ( ! is_array( $urls ) || count( $urls ) === 0 ) {
+			return;
+		}
+
+		$nginx_purger->log( "Preloading cache | BEGIN" );
+
+		foreach ( $urls as $url ) {
+
+			$nginx_purger->log( "- Preloading {$url}" );
+
+			wp_remote_get( $url );
+		}
+
+		$nginx_purger->log( "Preloaded cache | END ^^^" );
+
+	}
+
+	/**
+	 * Display plugin notices.
 	 */
 	public function display_notices() {
 		echo '<div class="updated"><p>' . esc_html__( 'Purge initiated', 'nginx-helper' ) . '</p></div>';

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -209,6 +209,7 @@ class Nginx_Helper {
 		$this->loader->add_action( 'wp_ajax_rt_get_feeds', $nginx_helper_admin, 'nginx_helper_get_feeds' );
 
 		$this->loader->add_action( 'shutdown', $nginx_helper_admin, 'add_timestamps', 99999 );
+		$this->loader->add_action( 'shutdown', $nginx_helper_admin, 'preload_urls', 999999 );
 		$this->loader->add_action( 'add_init', $nginx_helper_admin, 'update_map' );
 
 		// Add actions to purge.
@@ -227,6 +228,9 @@ class Nginx_Helper {
 
 		// expose action to allow other plugins to purge the cache.
 		$this->loader->add_action( 'rt_nginx_helper_purge_all', $nginx_purger, 'purge_all' );
+
+		// Add URLs to preload
+		$this->loader->add_action( 'transition_post_status', $nginx_helper_admin, 'preload_new_published_post', 20, 3 );
 	}
 
 	/**


### PR DESCRIPTION
Added a new filter named `rt_nginx_helper_preload_urls` which contains an array of URLs. Those URLs will be preloaded through the `shutdown` hook.

Get the current updated post from the `transition_post_status` hook and check whether the post status is **published** from a **non-published** status. Then the URL of the post will be added to the `rt_nginx_helper_preload_urls` filter so that the URL can be preloaded.

With the above process, a new post will be cached as soon as they got published. Also, the `rt_nginx_helper_preload_urls` filter can also be used to preload other URLs if needed in the future.