### PR TITLE
Add action that fires after the current page has been purged

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -740,6 +740,16 @@ class Nginx_Helper_Admin {
 			 */
 			do_action( 'rt_nginx_helper_after_purge_all' );
 
+		} else {
+			if ( 'purge_current_page' === $action ) {
+
+			/**
+			 * Fire an action after the current page has been purged whatever caching type is used.
+			 * 
+			 * @since 2.2.4
+			 */
+			do_action( 'rt_nginx_helper_after_purge_url' );
+			}
 		}
 
 		wp_redirect( esc_url_raw( $redirect_url ) );


### PR DESCRIPTION
There is already an action that fires after the entire cache has been purged, but there isn't one for when the current page has been purged. This new action is useful when using a caching plugin such as Cloudflare to purge the current page on Cloudflare as well.