### PR TITLE
Add two actions after custom_purge_url unlink_files and get_request

### DIFF
--- a/admin/class-fastcgi-purger.php
+++ b/admin/class-fastcgi-purger.php
@@ -132,6 +132,7 @@ class FastCGI_Purger extends Purger {
 
 						}
 					}
+					do_action( 'rt_nginx_helper_after_unlink_purge_urls' );
 				}
 				break;
 
@@ -154,6 +155,7 @@ class FastCGI_Purger extends Purger {
 
 						}
 					}
+					do_action( 'rt_nginx_helper_after_get_purge_urls' );
 				}
 				break;
 


### PR DESCRIPTION
Added actions rt_nginx_helper_after_unlink_purge_urls and rt_nginx_helper_after_get_purge_urls to fire after custom_purge_url unlink_files and get_request has been completed.