### PR TITLE
Update version in readme.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 **Requires at least:** 3.0
 
-**Tested up to:** 6.1
+**Tested up to:** 6.4.2
 
-**Stable tag:** 2.2.3
+**Stable tag:** 2.2.4
 
 **License:** GPLv2 or later (of-course)
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags: nginx, cache, purge, nginx map, nginx cache, maps, fastcgi, proxy, redis, 
 License: GPLv2 or later (of-course)
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 3.0
-Tested up to: 6.1
-Stable tag: 2.2.3
+Tested up to: 6.4.2
+Stable tag: 2.2.4
 
 Cleans nginx's fastcgi/proxy cache or redis-cache whenever a post is edited/published. Also does a few more things.
 


### PR DESCRIPTION
# Version Update for the Nginx Helper Plugin :arrow_double_up: 

Current Version: 2.2.3
Updating Version: 2.2.4

Updates to enhancements have been added in the Version Update as listed below.

Following is the changelog :spiral_notepad: from the previous version

= 2.2.4 =
* Introduces the capability to specify the `NGINX_HELPER_LOG` constant, allowing users to activate the logging feature.
* Existing users employing the nginx-helper plugin with logging enabled will experience no disruptions. However, if logging is disabled, users must define the `NGINX_HELPER_LOG` constant to re-enable the logging feature.
