### PR TITLE
Offload "Purge Entire Cache" request to cron service/schedule

### DIFF
--- a/admin/class-fastcgi-purger.php
+++ b/admin/class-fastcgi-purger.php
@@ -162,21 +162,31 @@ class FastCGI_Purger extends Purger {
 	}
 
 	/**
-	 * Purge everything.
+	 * Schedule Purge everything.
 	 */
-	public function purge_all() {
+	public function purge_all()
+	{
 
-		$this->unlink_recursive( RT_WP_NGINX_HELPER_CACHE_PATH, false );
-		$this->log( '* * * * *' );
-		$this->log( '* Purged Everything!' );
-		$this->log( '* * * * *' );
+		// Schedule the action if it's not already scheduled
+		// This to avoid overhead of buffering when there are too many directories
+		if (!wp_next_scheduled("nginx_helper_unlink_recursive")) {
+			wp_schedule_single_event(
+				time(),
+				"nginx_helper_unlink_recursive",
+				[RT_WP_NGINX_HELPER_CACHE_PATH, false]
+			);
+		}
+
+		$this->log('* * * * *');
+		$this->log('* Purged Everything has been scheduled');
+		$this->log('* * * * *');
 
 		/**
 		 * Fire an action after the FastCGI cache has been purged.
 		 *
 		 * @since 2.1.0
 		 */
-		do_action( 'rt_nginx_helper_after_fastcgi_purge_all' );
+		do_action('rt_nginx_helper_after_fastcgi_purge_all');
 	}
 
 	/**

--- a/admin/class-purger.php
+++ b/admin/class-purger.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -14,7 +15,13 @@
  *
  * @author     rtCamp
  */
-abstract class Purger {
+abstract class Purger
+{
+
+	public function __construct()
+	{
+		add_action('nginx_helper_unlink_recursive', [$this, 'run_cron_unlink_recursive'], 10, 2);
+	}
 
 	/**
 	 * Purge cache for url.
@@ -24,7 +31,7 @@ abstract class Purger {
 	 *
 	 * @return mixed
 	 */
-	abstract public function purge_url( $url, $feed = true );
+	abstract public function purge_url($url, $feed = true);
 
 	/**
 	 * Purge cache for custom url.
@@ -46,27 +53,27 @@ abstract class Purger {
 	 * @param int    $comment_id Comment id.
 	 * @param object $comment Comment data.
 	 */
-	public function purge_post_on_comment( $comment_id, $comment ) {
+	public function purge_post_on_comment($comment_id, $comment)
+	{
 
 		$oldstatus = '';
 		$approved  = $comment->comment_approved;
 
-		if ( null === $approved ) {
+		if (null === $approved) {
 			$newstatus = false;
-		} elseif ( '1' === $approved ) {
+		} elseif ('1' === $approved) {
 			$newstatus = 'approved';
-		} elseif ( '0' === $approved ) {
+		} elseif ('0' === $approved) {
 			$newstatus = 'unapproved';
-		} elseif ( 'spam' === $approved ) {
+		} elseif ('spam' === $approved) {
 			$newstatus = 'spam';
-		} elseif ( 'trash' === $approved ) {
+		} elseif ('trash' === $approved) {
 			$newstatus = 'trash';
 		} else {
 			$newstatus = false;
 		}
 
-		$this->purge_post_on_comment_change( $newstatus, $oldstatus, $comment );
-
+		$this->purge_post_on_comment_change($newstatus, $oldstatus, $comment);
 	}
 
 	/**
@@ -76,49 +83,46 @@ abstract class Purger {
 	 * @param string $oldstatus Old status.
 	 * @param object $comment Comment data.
 	 */
-	public function purge_post_on_comment_change( $newstatus, $oldstatus, $comment ) {
+	public function purge_post_on_comment_change($newstatus, $oldstatus, $comment)
+	{
 
 		global $nginx_helper_admin, $blog_id;
 
-		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+		if (!$nginx_helper_admin->options['enable_purge']) {
 			return;
 		}
 
 		$_post_id    = $comment->comment_post_ID;
 		$_comment_id = $comment->comment_ID;
 
-		$this->log( '* * * * *' );
-		$this->log( '* Blog :: ' . addslashes( get_bloginfo( 'name' ) ) . ' ( ' . $blog_id . ' ). ' );
-		$this->log( '* Post :: ' . get_the_title( $_post_id ) . ' ( ' . $_post_id . ' ) ' );
-		$this->log( "* Comment :: $_comment_id." );
-		$this->log( "* Status Changed from $oldstatus to $newstatus" );
+		$this->log('* * * * *');
+		$this->log('* Blog :: ' . addslashes(get_bloginfo('name')) . ' ( ' . $blog_id . ' ). ');
+		$this->log('* Post :: ' . get_the_title($_post_id) . ' ( ' . $_post_id . ' ) ');
+		$this->log("* Comment :: $_comment_id.");
+		$this->log("* Status Changed from $oldstatus to $newstatus");
 
-		switch ( $newstatus ) {
+		switch ($newstatus) {
 
 			case 'approved':
-				if ( 1 === (int) $nginx_helper_admin->options['purge_page_on_new_comment'] ) {
+				if (1 === (int) $nginx_helper_admin->options['purge_page_on_new_comment']) {
 
-					$this->log( '* Comment ( ' . $_comment_id . ' ) approved. Post ( ' . $_post_id . ' ) purging...' );
-					$this->log( '* * * * *' );
-					$this->purge_post( $_post_id );
-
+					$this->log('* Comment ( ' . $_comment_id . ' ) approved. Post ( ' . $_post_id . ' ) purging...');
+					$this->log('* * * * *');
+					$this->purge_post($_post_id);
 				}
 				break;
 
 			case 'spam':
 			case 'unapproved':
 			case 'trash':
-				if ( 'approved' === $oldstatus && 1 === (int) $nginx_helper_admin->options['purge_page_on_deleted_comment'] ) {
+				if ('approved' === $oldstatus && 1 === (int) $nginx_helper_admin->options['purge_page_on_deleted_comment']) {
 
-					$this->log( '* Comment ( ' . $_comment_id . ' ) removed as ( ' . $newstatus . ' ). Post ( ' . $_post_id . ' ) purging...' );
-					$this->log( '* * * * *' );
-					$this->purge_post( $_post_id );
-
+					$this->log('* Comment ( ' . $_comment_id . ' ) removed as ( ' . $newstatus . ' ). Post ( ' . $_post_id . ' ) purging...');
+					$this->log('* * * * *');
+					$this->purge_post($_post_id);
 				}
 				break;
-
 		}
-
 	}
 
 	/**
@@ -126,30 +130,31 @@ abstract class Purger {
 	 *
 	 * @param int $post_id Post id.
 	 */
-	public function purge_post( $post_id ) {
+	public function purge_post($post_id)
+	{
 
 		global $nginx_helper_admin, $blog_id;
 
-		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+		if (!$nginx_helper_admin->options['enable_purge']) {
 			return;
 		}
 
-		switch ( current_filter() ) {
+		switch (current_filter()) {
 
 			case 'publish_post':
-				$this->log( '* * * * *' );
-				$this->log( '* Blog :: ' . addslashes( get_bloginfo( 'name' ) ) . ' ( ' . $blog_id . ' ).' );
-				$this->log( '* Post :: ' . get_the_title( $post_id ) . ' ( ' . $post_id . ' ).' );
-				$this->log( '* Post ( ' . $post_id . ' ) published or edited and its status is published' );
-				$this->log( '* * * * *' );
+				$this->log('* * * * *');
+				$this->log('* Blog :: ' . addslashes(get_bloginfo('name')) . ' ( ' . $blog_id . ' ).');
+				$this->log('* Post :: ' . get_the_title($post_id) . ' ( ' . $post_id . ' ).');
+				$this->log('* Post ( ' . $post_id . ' ) published or edited and its status is published');
+				$this->log('* * * * *');
 				break;
 
 			case 'publish_page':
-				$this->log( '* * * * *' );
-				$this->log( '* Blog :: ' . addslashes( get_bloginfo( 'name' ) ) . ' ( ' . $blog_id . ' ).' );
-				$this->log( '* Page :: ' . get_the_title( $post_id ) . ' ( ' . $post_id . ' ).' );
-				$this->log( '* Page ( ' . $post_id . ' ) published or edited and its status is published' );
-				$this->log( '* * * * *' );
+				$this->log('* * * * *');
+				$this->log('* Blog :: ' . addslashes(get_bloginfo('name')) . ' ( ' . $blog_id . ' ).');
+				$this->log('* Page :: ' . get_the_title($post_id) . ' ( ' . $post_id . ' ).');
+				$this->log('* Page ( ' . $post_id . ' ) published or edited and its status is published');
+				$this->log('* * * * *');
 				break;
 
 			case 'comment_post':
@@ -157,23 +162,22 @@ abstract class Purger {
 				break;
 
 			default:
-				$_post_type = get_post_type( $post_id );
-				$this->log( '* * * * *' );
-				$this->log( '* Blog :: ' . addslashes( get_bloginfo( 'name' ) ) . ' ( ' . $blog_id . ' ).' );
-				$this->log( "* Custom post type '" . $_post_type . "' :: " . get_the_title( $post_id ) . ' ( ' . $post_id . ' ).' );
-				$this->log( "* CPT '" . $_post_type . "' ( " . $post_id . ' ) published or edited and its status is published' );
-				$this->log( '* * * * *' );
+				$_post_type = get_post_type($post_id);
+				$this->log('* * * * *');
+				$this->log('* Blog :: ' . addslashes(get_bloginfo('name')) . ' ( ' . $blog_id . ' ).');
+				$this->log("* Custom post type '" . $_post_type . "' :: " . get_the_title($post_id) . ' ( ' . $post_id . ' ).');
+				$this->log("* CPT '" . $_post_type . "' ( " . $post_id . ' ) published or edited and its status is published');
+				$this->log('* * * * *');
 				break;
-
 		}
 
-		$this->log( 'Function purge_post BEGIN ===' );
+		$this->log('Function purge_post BEGIN ===');
 
-		if ( 1 === (int) $nginx_helper_admin->options['purge_homepage_on_edit'] ) {
+		if (1 === (int) $nginx_helper_admin->options['purge_homepage_on_edit']) {
 			$this->_purge_homepage();
 		}
 
-		if ( 'comment_post' === current_filter() || 'wp_set_comment_status' === current_filter() ) {
+		if ('comment_post' === current_filter() || 'wp_set_comment_status' === current_filter()) {
 
 			$this->_purge_by_options(
 				$post_id,
@@ -182,7 +186,6 @@ abstract class Purger {
 				$nginx_helper_admin->options['purge_archive_on_new_comment'],
 				$nginx_helper_admin->options['purge_archive_on_new_comment']
 			);
-
 		} else {
 
 			$this->_purge_by_options(
@@ -192,12 +195,11 @@ abstract class Purger {
 				$nginx_helper_admin->options['purge_archive_on_edit'],
 				$nginx_helper_admin->options['purge_archive_on_edit']
 			);
-
 		}
 
 		$this->custom_purge_urls();
 
-		$this->log( 'Function purge_post END ^^^' );
+		$this->log('Function purge_post END ^^^');
 	}
 
 	/**
@@ -209,124 +211,120 @@ abstract class Purger {
 	 * @param bool $_purge_archive Purge archive or not.
 	 * @param bool $_purge_custom_taxa Purge taxonomy or not.
 	 */
-	private function _purge_by_options( $post_id, $blog_id, $_purge_page, $_purge_archive, $_purge_custom_taxa ) {
+	private function _purge_by_options($post_id, $blog_id, $_purge_page, $_purge_archive, $_purge_custom_taxa)
+	{
 
-		$_post_type = get_post_type( $post_id );
+		$_post_type = get_post_type($post_id);
 
-		if ( $_purge_page ) {
+		if ($_purge_page) {
 
-			if ( 'post' === $_post_type || 'page' === $_post_type ) {
-				$this->log( 'Purging ' . $_post_type . ' ( id ' . $post_id . ', blog id ' . $blog_id . ' ) ' );
+			if ('post' === $_post_type || 'page' === $_post_type) {
+				$this->log('Purging ' . $_post_type . ' ( id ' . $post_id . ', blog id ' . $blog_id . ' ) ');
 			} else {
-				$this->log( "Purging custom post type '" . $_post_type . "' ( id " . $post_id . ', blog id ' . $blog_id . ' )' );
+				$this->log("Purging custom post type '" . $_post_type . "' ( id " . $post_id . ', blog id ' . $blog_id . ' )');
 			}
 
-			$post_status = get_post_status( $post_id );
+			$post_status = get_post_status($post_id);
 
-			if ( 'publish' !== $post_status ) {
+			if ('publish' !== $post_status) {
 
-				if ( ! function_exists( 'get_sample_permalink' ) ) {
+				if (!function_exists('get_sample_permalink')) {
 					require_once ABSPATH . '/wp-admin/includes/post.php';
 				}
 
-				$url = get_sample_permalink( $post_id );
+				$url = get_sample_permalink($post_id);
 
-				if ( ! empty( $url[0] ) && ! empty( $url[1] ) ) {
-					$url = str_replace( array('%postname%', '%pagename%'), $url[1], $url[0] );
+				if (!empty($url[0]) && !empty($url[1])) {
+					$url = str_replace(array('%postname%', '%pagename%'), $url[1], $url[0]);
 				} else {
 					$url = '';
 				}
 			} else {
-				$url = get_permalink( $post_id );
+				$url = get_permalink($post_id);
 			}
 
-			if ( empty( $url ) && ! is_array( $url ) ) {
+			if (empty($url) && !is_array($url)) {
 				return;
 			}
 
-			if ( 'trash' === get_post_status( $post_id ) ) {
-				$url = str_replace( '__trashed', '', $url );
+			if ('trash' === get_post_status($post_id)) {
+				$url = str_replace('__trashed', '', $url);
 			}
 
-			$this->purge_url( $url );
-
+			$this->purge_url($url);
 		}
 
-		if ( $_purge_archive ) {
+		if ($_purge_archive) {
 
-			$_post_type_archive_link = get_post_type_archive_link( $_post_type );
+			$_post_type_archive_link = get_post_type_archive_link($_post_type);
 
-			if ( function_exists( 'get_post_type_archive_link' ) && $_post_type_archive_link ) {
+			if (function_exists('get_post_type_archive_link') && $_post_type_archive_link) {
 
-				$this->log( 'Purging post type archive ( ' . $_post_type . ' )' );
-				$this->purge_url( $_post_type_archive_link );
-
+				$this->log('Purging post type archive ( ' . $_post_type . ' )');
+				$this->purge_url($_post_type_archive_link);
 			}
 
-			$post_types = get_post_types( array( 'public' => true ) );
+			$post_types = get_post_types(array('public' => true));
 
-			if ( in_array( $_post_type, $post_types, true ) ) {
+			if (in_array($_post_type, $post_types, true)) {
 
-				$this->log( 'Purging date' );
+				$this->log('Purging date');
 
-				$day   = get_the_time( 'd', $post_id );
-				$month = get_the_time( 'm', $post_id );
-				$year  = get_the_time( 'Y', $post_id );
+				$day   = get_the_time('d', $post_id);
+				$month = get_the_time('m', $post_id);
+				$year  = get_the_time('Y', $post_id);
 
-				if ( $year ) {
+				if ($year) {
 
-					$this->purge_url( get_year_link( $year ) );
+					$this->purge_url(get_year_link($year));
 
-					if ( $month ) {
+					if ($month) {
 
-						$this->purge_url( get_month_link( $year, $month ) );
+						$this->purge_url(get_month_link($year, $month));
 
-						if ( $day ) {
-							$this->purge_url( get_day_link( $year, $month, $day ) );
+						if ($day) {
+							$this->purge_url(get_day_link($year, $month, $day));
 						}
 					}
 				}
 			}
 
-			$categories = wp_get_post_categories( $post_id );
+			$categories = wp_get_post_categories($post_id);
 
-			if ( ! is_wp_error( $categories ) ) {
+			if (!is_wp_error($categories)) {
 
-				$this->log( 'Purging category archives' );
+				$this->log('Purging category archives');
 
-				foreach ( $categories as $category_id ) {
+				foreach ($categories as $category_id) {
 
-					$this->log( 'Purging category ' . $category_id );
-					$this->purge_url( get_category_link( $category_id ) );
-
+					$this->log('Purging category ' . $category_id);
+					$this->purge_url(get_category_link($category_id));
 				}
 			}
 
-			$tags = get_the_tags( $post_id );
+			$tags = get_the_tags($post_id);
 
-			if ( ! is_wp_error( $tags ) && ! empty( $tags ) ) {
+			if (!is_wp_error($tags) && !empty($tags)) {
 
-				$this->log( 'Purging tag archives' );
+				$this->log('Purging tag archives');
 
-				foreach ( $tags as $tag ) {
+				foreach ($tags as $tag) {
 
-					$this->log( 'Purging tag ' . $tag->term_id );
-					$this->purge_url( get_tag_link( $tag->term_id ) );
-
+					$this->log('Purging tag ' . $tag->term_id);
+					$this->purge_url(get_tag_link($tag->term_id));
 				}
 			}
 
-			$author_id = get_post( $post_id )->post_author;
+			$author_id = get_post($post_id)->post_author;
 
-			if ( ! empty( $author_id ) ) {
+			if (!empty($author_id)) {
 
-				$this->log( 'Purging author archive' );
-				$this->purge_url( get_author_posts_url( $author_id ) );
-
+				$this->log('Purging author archive');
+				$this->purge_url(get_author_posts_url($author_id));
 			}
 		}
 
-		if ( $_purge_custom_taxa ) {
+		if ($_purge_custom_taxa) {
 
 			$custom_taxonomies = get_taxonomies(
 				array(
@@ -335,24 +333,24 @@ abstract class Purger {
 				)
 			);
 
-			if ( ! empty( $custom_taxonomies ) ) {
+			if (!empty($custom_taxonomies)) {
 
-				$this->log( 'Purging custom taxonomies related' );
+				$this->log('Purging custom taxonomies related');
 
-				foreach ( $custom_taxonomies as $taxon ) {
+				foreach ($custom_taxonomies as $taxon) {
 
-					if ( ! in_array( $taxon, array( 'category', 'post_tag', 'link_category' ), true ) ) {
+					if (!in_array($taxon, array('category', 'post_tag', 'link_category'), true)) {
 
-						$terms = get_the_terms( $post_id, $taxon );
+						$terms = get_the_terms($post_id, $taxon);
 
-						if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+						if (!is_wp_error($terms) && !empty($terms)) {
 
-							foreach ( $terms as $term ) {
-								$this->purge_url( get_term_link( $term, $taxon ) );
+							foreach ($terms as $term) {
+								$this->purge_url(get_term_link($term, $taxon));
 							}
 						}
 					} else {
-						$this->log( "Your built-in taxonomy '" . $taxon . "' has param '_builtin' set to false.", 'WARNING' );
+						$this->log("Your built-in taxonomy '" . $taxon . "' has param '_builtin' set to false.", 'WARNING');
 					}
 				}
 			}
@@ -369,35 +367,34 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	protected function delete_cache_file_for( $url ) {
+	protected function delete_cache_file_for($url)
+	{
 
 		// Verify cache path is set.
-		if ( ! defined( 'RT_WP_NGINX_HELPER_CACHE_PATH' ) ) {
+		if (!defined('RT_WP_NGINX_HELPER_CACHE_PATH')) {
 
-			$this->log( 'Error purging because RT_WP_NGINX_HELPER_CACHE_PATH was not defined. URL: ' . $url, 'ERROR' );
+			$this->log('Error purging because RT_WP_NGINX_HELPER_CACHE_PATH was not defined. URL: ' . $url, 'ERROR');
 			return false;
-
 		}
 
 		// Verify URL is valid.
-		$url_data = wp_parse_url( $url );
-		if ( ! $url_data ) {
+		$url_data = wp_parse_url($url);
+		if (!$url_data) {
 
-			$this->log( 'Error purging because specified URL did not appear to be valid. URL: ' . $url, 'ERROR' );
+			$this->log('Error purging because specified URL did not appear to be valid. URL: ' . $url, 'ERROR');
 			return false;
-
 		}
 
 		// Build a hash of the URL.
-		$url_path = isset( $url_data['path'] ) ? $url_data['path'] : '';
-		$hash = md5( $url_data['scheme'] . 'GET' . $url_data['host'] . $url_path );
+		$url_path = isset($url_data['path']) ? $url_data['path'] : '';
+		$hash = md5($url_data['scheme'] . 'GET' . $url_data['host'] . $url_path);
 
 		// Ensure trailing slash.
 		$cache_path = RT_WP_NGINX_HELPER_CACHE_PATH;
-		$cache_path = ( '/' === substr( $cache_path, -1 ) ) ? $cache_path : $cache_path . '/';
+		$cache_path = ('/' === substr($cache_path, -1)) ? $cache_path : $cache_path . '/';
 
 		// Set path to cached file.
-		$cached_file = $cache_path . substr( $hash, -1 ) . '/' . substr( $hash, -3, 2 ) . '/' . $hash;
+		$cached_file = $cache_path . substr($hash, -1) . '/' . substr($hash, -3, 2) . '/' . $hash;
 
 		/**
 		 * Filters the cached file name.
@@ -408,19 +405,18 @@ abstract class Purger {
 		 * @param string $cached_file Cached file name.
 		 * @param string $url         URL to be purged.
 		 */
-		$cached_file = apply_filters( 'rt_nginx_helper_purge_cached_file', $cached_file, $url );
+		$cached_file = apply_filters('rt_nginx_helper_purge_cached_file', $cached_file, $url);
 
 		// Verify cached file exists.
-		if ( ! file_exists( $cached_file ) ) {
+		if (!file_exists($cached_file)) {
 
-			$this->log( '- - ' . $url . ' is currently not cached ( checked for file: ' . $cached_file . ' )' );
+			$this->log('- - ' . $url . ' is currently not cached ( checked for file: ' . $cached_file . ' )');
 			return false;
-
 		}
 
 		// Delete the cached file.
-		if ( unlink( $cached_file ) ) {
-			$this->log( '- - ' . $url . ' *** PURGED ***' );
+		if (unlink($cached_file)) {
+			$this->log('- - ' . $url . ' *** PURGED ***');
 
 			/**
 			 * Fire an action after deleting file from cache.
@@ -430,11 +426,10 @@ abstract class Purger {
 			 * @param string $url         URL to be purged.
 			 * @param string $cached_file Cached file name.
 			 */
-			do_action( 'rt_nginx_helper_purged_file', $url, $cached_file );
+			do_action('rt_nginx_helper_purged_file', $url, $cached_file);
 		} else {
-			$this->log( '- - An error occurred deleting the cache file. Check the server logs for a PHP warning.', 'ERROR' );
+			$this->log('- - An error occurred deleting the cache file. Check the server logs for a PHP warning.', 'ERROR');
 		}
-
 	}
 
 	/**
@@ -442,7 +437,8 @@ abstract class Purger {
 	 *
 	 * @param string $url URL to do remote request.
 	 */
-	protected function do_remote_get( $url ) {
+	protected function do_remote_get($url)
+	{
 		/**
 		 * Filters the URL to be purged.
 		 *
@@ -450,7 +446,7 @@ abstract class Purger {
 		 *
 		 * @param string $url URL to be purged.
 		 */
-		$url = apply_filters( 'rt_nginx_helper_remote_purge_url', $url );
+		$url = apply_filters('rt_nginx_helper_remote_purge_url', $url);
 
 		/**
 		 * Fire an action before purging URL.
@@ -459,30 +455,28 @@ abstract class Purger {
 		 *
 		 * @param string $url URL to be purged.
 		 */
-		do_action( 'rt_nginx_helper_before_remote_purge_url', $url );
+		do_action('rt_nginx_helper_before_remote_purge_url', $url);
 
-		$response = wp_remote_get( $url );
+		$response = wp_remote_get($url);
 
-		if ( is_wp_error( $response ) ) {
+		if (is_wp_error($response)) {
 
-			$_errors_str = implode( ' - ', $response->get_error_messages() );
-			$this->log( 'Error while purging URL. ' . $_errors_str, 'ERROR' );
-
+			$_errors_str = implode(' - ', $response->get_error_messages());
+			$this->log('Error while purging URL. ' . $_errors_str, 'ERROR');
 		} else {
 
-			if ( $response['response']['code'] ) {
+			if ($response['response']['code']) {
 
-				switch ( $response['response']['code'] ) {
+				switch ($response['response']['code']) {
 
 					case 200:
-						$this->log( '- - ' . $url . ' *** PURGED ***' );
+						$this->log('- - ' . $url . ' *** PURGED ***');
 						break;
 					case 404:
-						$this->log( '- - ' . $url . ' is currently not cached' );
+						$this->log('- - ' . $url . ' is currently not cached');
 						break;
 					default:
-						$this->log( '- - ' . $url . ' not found ( ' . $response['response']['code'] . ' )', 'WARNING' );
-
+						$this->log('- - ' . $url . ' not found ( ' . $response['response']['code'] . ' )', 'WARNING');
 				}
 			}
 
@@ -494,9 +488,8 @@ abstract class Purger {
 			 * @param string $url      URL to be purged.
 			 * @param array  $response Array of results including HTTP headers.
 			 */
-			do_action( 'rt_nginx_helper_after_remote_purge_url', $url, $response );
+			do_action('rt_nginx_helper_after_remote_purge_url', $url, $response);
 		}
-
 	}
 
 	/**
@@ -504,17 +497,17 @@ abstract class Purger {
 	 *
 	 * @return string
 	 */
-	public function check_http_connection() {
+	public function check_http_connection()
+	{
 
-		$purge_url = plugins_url( 'nginx-manager/check-proxy.php' );
-		$response  = wp_remote_get( $purge_url );
+		$purge_url = plugins_url('nginx-manager/check-proxy.php');
+		$response  = wp_remote_get($purge_url);
 
-		if ( ! is_wp_error( $response ) && ( 'HTTP Connection OK' === $response['body'] ) ) {
+		if (!is_wp_error($response) && ('HTTP Connection OK' === $response['body'])) {
 			return 'OK';
 		}
 
 		return 'KO';
-
 	}
 
 	/**
@@ -525,11 +518,12 @@ abstract class Purger {
 	 *
 	 * @return bool|void
 	 */
-	public function log( $msg, $level = 'INFO' ) {
+	public function log($msg, $level = 'INFO')
+	{
 
 		global $nginx_helper_admin;
 
-		if ( ! $nginx_helper_admin->is_nginx_log_enabled() ) {
+		if (!$nginx_helper_admin->is_nginx_log_enabled()) {
 			return;
 		}
 
@@ -540,53 +534,52 @@ abstract class Purger {
 			'NONE'    => 3,
 		);
 
-		if ( $log_levels[ $level ] >= $log_levels[ $nginx_helper_admin->options['log_level'] ] ) {
+		if ($log_levels[$level] >= $log_levels[$nginx_helper_admin->options['log_level']]) {
 
-			$fp = fopen( $nginx_helper_admin->functional_asset_path() . 'nginx.log', 'a+' );
-			if ( $fp ) {
+			$fp = fopen($nginx_helper_admin->functional_asset_path() . 'nginx.log', 'a+');
+			if ($fp) {
 
-				fwrite( $fp, "\n" . gmdate( 'Y-m-d H:i:s ' ) . ' | ' . $level . ' | ' . $msg );
-				fclose( $fp );
-
+				fwrite($fp, "\n" . gmdate('Y-m-d H:i:s ') . ' | ' . $level . ' | ' . $msg);
+				fclose($fp);
 			}
 		}
 
 		return true;
-
 	}
 
 	/**
 	 * Check and truncate log file.
 	 */
-	public function check_and_truncate_log_file() {
+	public function check_and_truncate_log_file()
+	{
 
 		global $nginx_helper_admin;
 
-		if ( ! $nginx_helper_admin->is_nginx_log_enabled() ) {
+		if (!$nginx_helper_admin->is_nginx_log_enabled()) {
 			return;
 		}
 
 		$nginx_asset_path = $nginx_helper_admin->functional_asset_path() . 'nginx.log';
 
-		if ( ! file_exists( $nginx_asset_path ) ) {
+		if (!file_exists($nginx_asset_path)) {
 			return;
 		}
 
-		$max_size_allowed = ( is_numeric( $nginx_helper_admin->options['log_filesize'] ) ) ? $nginx_helper_admin->options['log_filesize'] * 1048576 : 5242880;
+		$max_size_allowed = (is_numeric($nginx_helper_admin->options['log_filesize'])) ? $nginx_helper_admin->options['log_filesize'] * 1048576 : 5242880;
 
-		$file_size = filesize( $nginx_asset_path );
+		$file_size = filesize($nginx_asset_path);
 
-		if ( $file_size > $max_size_allowed ) {
+		if ($file_size > $max_size_allowed) {
 
 			$offset       = $file_size - $max_size_allowed;
-			$file_content = file_get_contents( $nginx_asset_path, null, null, $offset );
-			$file_content = empty( $file_content ) ? '' : strstr( $file_content, "\n" );
+			$file_content = file_get_contents($nginx_asset_path, false, null, $offset);
+			$file_content = empty($file_content) ? '' : strstr($file_content, "\n");
 
-			$fp = fopen( $nginx_asset_path, 'w+' );
-			if ( $file_content && $fp ) {
+			$fp = fopen($nginx_asset_path, 'w+');
+			if ($file_content && $fp) {
 
-				fwrite( $fp, $file_content );
-				fclose( $fp );
+				fwrite($fp, $file_content);
+				fclose($fp);
 			}
 		}
 	}
@@ -596,42 +589,41 @@ abstract class Purger {
 	 *
 	 * @param int $attachment_id Attachment id.
 	 */
-	public function purge_image_on_edit( $attachment_id ) {
+	public function purge_image_on_edit($attachment_id)
+	{
 
 		global $nginx_helper_admin;
 
 		// Do not purge if not enabled.
-		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+		if (!$nginx_helper_admin->options['enable_purge']) {
 			return;
 		}
 
-		$this->log( 'Purging media on edit BEGIN ===' );
+		$this->log('Purging media on edit BEGIN ===');
 
-		if ( wp_attachment_is_image( $attachment_id ) ) {
+		if (wp_attachment_is_image($attachment_id)) {
 
-			$this->purge_url( wp_get_attachment_url( $attachment_id ), false );
-			$attachment = wp_get_attachment_metadata( $attachment_id );
+			$this->purge_url(wp_get_attachment_url($attachment_id), false);
+			$attachment = wp_get_attachment_metadata($attachment_id);
 
-			if ( ! empty( $attachment['sizes'] ) && is_array( $attachment['sizes'] ) ) {
+			if (!empty($attachment['sizes']) && is_array($attachment['sizes'])) {
 
-				foreach ( array_keys( $attachment['sizes'] ) as $size_name ) {
+				foreach (array_keys($attachment['sizes']) as $size_name) {
 
-					$resize_image = wp_get_attachment_image_src( $attachment_id, $size_name );
+					$resize_image = wp_get_attachment_image_src($attachment_id, $size_name);
 
-					if ( $resize_image ) {
-						$this->purge_url( $resize_image[0], false );
+					if ($resize_image) {
+						$this->purge_url($resize_image[0], false);
 					}
 				}
 			}
 
-			$this->purge_url( get_attachment_link( $attachment_id ) );
-
+			$this->purge_url(get_attachment_link($attachment_id));
 		} else {
-			$this->log( 'Media ( id ' . $attachment_id . ') edited: no image', 'WARNING' );
+			$this->log('Media ( id ' . $attachment_id . ') edited: no image', 'WARNING');
 		}
 
-		$this->log( 'Purging media on edit END ^^^' );
-
+		$this->log('Purging media on edit END ^^^');
 	}
 
 	/**
@@ -643,22 +635,23 @@ abstract class Purger {
 	 *
 	 * @return bool|void
 	 */
-	public function purge_on_post_moved_to_trash( $new_status, $old_status, $post ) {
+	public function purge_on_post_moved_to_trash($new_status, $old_status, $post)
+	{
 
 		global $nginx_helper_admin, $blog_id;
 
-		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+		if (!$nginx_helper_admin->options['enable_purge']) {
 			return;
 		}
 
-		if ( 'trash' === $new_status ) {
+		if ('trash' === $new_status) {
 
-			$this->log( '# # # # #' );
-			$this->log( "# Post '$post->post_title' (  id " . $post->ID . ' ) moved to the trash.' );
-			$this->log( '# # # # #' );
-			$this->log( 'Function purge_on_post_moved_to_trash ( post id ' . $post->ID . ' ) BEGIN ===' );
+			$this->log('# # # # #');
+			$this->log("# Post '$post->post_title' (  id " . $post->ID . ' ) moved to the trash.');
+			$this->log('# # # # #');
+			$this->log('Function purge_on_post_moved_to_trash ( post id ' . $post->ID . ' ) BEGIN ===');
 
-			if ( 1 === (int) $nginx_helper_admin->options['purge_homepage_on_del'] ) {
+			if (1 === (int) $nginx_helper_admin->options['purge_homepage_on_del']) {
 				$this->_purge_homepage();
 			}
 
@@ -670,11 +663,10 @@ abstract class Purger {
 				$nginx_helper_admin->options['purge_archive_on_del']
 			);
 
-			$this->log( 'Function purge_on_post_moved_to_trash ( post id ' . $post->ID . ' ) END ===' );
+			$this->log('Function purge_on_post_moved_to_trash ( post id ' . $post->ID . ' ) END ===');
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -682,25 +674,23 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_homepage() {
+	private function _purge_homepage()
+	{
 
 		// WPML installetd?.
-		if ( function_exists( 'icl_get_home_url' ) ) {
-
-			$homepage_url = trailingslashit( icl_get_home_url() );
-			$this->log( sprintf( __( 'Purging homepage (WPML) ', 'nginx-helper' ) . '%s', $homepage_url ) );
-
+		if (function_exists('icl_get_home_url')) {
+			/** @disregard P1010 */
+			$homepage_url = trailingslashit(icl_get_home_url());
+			$this->log(sprintf(__('Purging homepage (WPML) ', 'nginx-helper') . '%s', $homepage_url));
 		} else {
 
-			$homepage_url = trailingslashit( home_url() );
-			$this->log( sprintf( __( 'Purging homepage ', 'nginx-helper' ) . '%s', $homepage_url ) );
-
+			$homepage_url = trailingslashit(home_url());
+			$this->log(sprintf(__('Purging homepage ', 'nginx-helper') . '%s', $homepage_url));
 		}
 
-		$this->purge_url( $homepage_url );
+		$this->purge_url($homepage_url);
 
 		return true;
-
 	}
 
 	/**
@@ -708,23 +698,23 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_personal_urls() {
+	private function _purge_personal_urls()
+	{
 
 		global $nginx_helper_admin;
 
-		$this->log( __( 'Purging personal urls', 'nginx-helper' ) );
+		$this->log(__('Purging personal urls', 'nginx-helper'));
 
-		if ( isset( $nginx_helper_admin->options['purgeable_url']['urls'] ) ) {
+		if (isset($nginx_helper_admin->options['purgeable_url']['urls'])) {
 
-			foreach ( $nginx_helper_admin->options['purgeable_url']['urls'] as $url ) {
-				$this->purge_url( $url, false );
+			foreach ($nginx_helper_admin->options['purgeable_url']['urls'] as $url) {
+				$this->purge_url($url, false);
 			}
 		} else {
-			$this->log( '- ' . __( 'No personal urls available', 'nginx-helper' ) );
+			$this->log('- ' . __('No personal urls available', 'nginx-helper'));
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -734,20 +724,20 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_post_categories( $_post_id ) {
+	private function _purge_post_categories($_post_id)
+	{
 
-		$this->log( __( 'Purging category archives', 'nginx-helper' ) );
+		$this->log(__('Purging category archives', 'nginx-helper'));
 
-		$categories = wp_get_post_categories( $_post_id );
+		$categories = wp_get_post_categories($_post_id);
 
-		if ( ! is_wp_error( $categories ) && ! empty( $categories ) ) {
+		if (!is_wp_error($categories) && !empty($categories)) {
 
-			foreach ( $categories as $category_id ) {
+			foreach ($categories as $category_id) {
 
 				// translators: %d: Category ID.
-				$this->log( sprintf( __( "Purging category '%d'", 'nginx-helper' ), $category_id ) );
-				$this->purge_url( get_category_link( $category_id ) );
-
+				$this->log(sprintf(__("Purging category '%d'", 'nginx-helper'), $category_id));
+				$this->purge_url(get_category_link($category_id));
 			}
 		}
 
@@ -761,24 +751,23 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_post_tags( $_post_id ) {
+	private function _purge_post_tags($_post_id)
+	{
 
-		$this->log( __( 'Purging tags archives', 'nginx-helper' ) );
+		$this->log(__('Purging tags archives', 'nginx-helper'));
 
-		$tags = get_the_tags( $_post_id );
+		$tags = get_the_tags($_post_id);
 
-		if ( ! is_wp_error( $tags ) && ! empty( $tags ) ) {
+		if (!is_wp_error($tags) && !empty($tags)) {
 
-			foreach ( $tags as $tag ) {
+			foreach ($tags as $tag) {
 
-				$this->log( sprintf( __( "Purging tag '%1\$s' ( id %2\$d )", 'nginx-helper' ), $tag->name, $tag->term_id ) );
-				$this->purge_url( get_tag_link( $tag->term_id ) );
-
+				$this->log(sprintf(__("Purging tag '%1\$s' ( id %2\$d )", 'nginx-helper'), $tag->name, $tag->term_id));
+				$this->purge_url(get_tag_link($tag->term_id));
 			}
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -788,9 +777,10 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_post_custom_taxa( $_post_id ) {
+	private function _purge_post_custom_taxa($_post_id)
+	{
 
-		$this->log( __( 'Purging post custom taxonomies related', 'nginx-helper' ) );
+		$this->log(__('Purging post custom taxonomies related', 'nginx-helper'));
 
 		$custom_taxonomies = get_taxonomies(
 			array(
@@ -799,30 +789,30 @@ abstract class Purger {
 			)
 		);
 
-		if ( ! empty( $custom_taxonomies ) ) {
+		if (!empty($custom_taxonomies)) {
 
-			foreach ( $custom_taxonomies as $taxon ) {
+			foreach ($custom_taxonomies as $taxon) {
 
 				// translators: %s: Post taxonomy name.
-				$this->log( sprintf( '+ ' . __( "Purging custom taxonomy '%s'", 'nginx-helper' ), $taxon ) );
+				$this->log(sprintf('+ ' . __("Purging custom taxonomy '%s'", 'nginx-helper'), $taxon));
 
-				if ( ! in_array( $taxon, array( 'category', 'post_tag', 'link_category' ), true ) ) {
+				if (!in_array($taxon, array('category', 'post_tag', 'link_category'), true)) {
 
-					$terms = get_the_terms( $_post_id, $taxon );
+					$terms = get_the_terms($_post_id, $taxon);
 
-					if ( ! is_wp_error( $terms ) && ! empty( $terms ) && is_array( $terms ) ) {
+					if (!is_wp_error($terms) && !empty($terms) && is_array($terms)) {
 
-						foreach ( $terms as $term ) {
-							$this->purge_url( get_term_link( $term, $taxon ) );
+						foreach ($terms as $term) {
+							$this->purge_url(get_term_link($term, $taxon));
 						}
 					}
 				} else {
 					// translators: %s: Post taxonomy name.
-					$this->log( sprintf( '- ' . __( "Your built-in taxonomy '%s' has param '_builtin' set to false.", 'nginx-helper' ), $taxon ), 'WARNING' );
+					$this->log(sprintf('- ' . __("Your built-in taxonomy '%s' has param '_builtin' set to false.", 'nginx-helper'), $taxon), 'WARNING');
 				}
 			}
 		} else {
-			$this->log( '- ' . __( 'No custom taxonomies', 'nginx-helper' ) );
+			$this->log('- ' . __('No custom taxonomies', 'nginx-helper'));
 		}
 
 		return true;
@@ -833,24 +823,23 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_all_categories() {
+	private function _purge_all_categories()
+	{
 
-		$this->log( __( 'Purging all categories', 'nginx-helper' ) );
+		$this->log(__('Purging all categories', 'nginx-helper'));
 
 		$_categories = get_categories();
 
-		if ( ! empty( $_categories ) ) {
+		if (!empty($_categories)) {
 
-			foreach ( $_categories as $c ) {
+			foreach ($_categories as $c) {
 
-				$this->log( sprintf( __( "Purging category '%1\$s' ( id %2\$d )", 'nginx-helper' ), $c->name, $c->term_id ) );
-				$this->purge_url( get_category_link( $c->term_id ) );
-
+				$this->log(sprintf(__("Purging category '%1\$s' ( id %2\$d )", 'nginx-helper'), $c->name, $c->term_id));
+				$this->purge_url(get_category_link($c->term_id));
 			}
 		} else {
 
-			$this->log( __( 'No categories archives', 'nginx-helper' ) );
-
+			$this->log(__('No categories archives', 'nginx-helper'));
 		}
 
 		return true;
@@ -861,26 +850,25 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_all_posttags() {
+	private function _purge_all_posttags()
+	{
 
-		$this->log( __( 'Purging all tags', 'nginx-helper' ) );
+		$this->log(__('Purging all tags', 'nginx-helper'));
 
 		$_posttags = get_tags();
 
-		if ( ! empty( $_posttags ) ) {
+		if (!empty($_posttags)) {
 
-			foreach ( $_posttags as $t ) {
+			foreach ($_posttags as $t) {
 
-				$this->log( sprintf( __( "Purging tag '%1\$s' ( id %2\$d )", 'nginx-helper' ), $t->name, $t->term_id ) );
-				$this->purge_url( get_tag_link( $t->term_id ) );
-
+				$this->log(sprintf(__("Purging tag '%1\$s' ( id %2\$d )", 'nginx-helper'), $t->name, $t->term_id));
+				$this->purge_url(get_tag_link($t->term_id));
 			}
 		} else {
-			$this->log( __( 'No tags archives', 'nginx-helper' ) );
+			$this->log(__('No tags archives', 'nginx-helper'));
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -888,9 +876,10 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_all_customtaxa() {
+	private function _purge_all_customtaxa()
+	{
 
-		$this->log( __( 'Purging all custom taxonomies', 'nginx-helper' ) );
+		$this->log(__('Purging all custom taxonomies', 'nginx-helper'));
 
 		$custom_taxonomies = get_taxonomies(
 			array(
@@ -899,32 +888,31 @@ abstract class Purger {
 			)
 		);
 
-		if ( ! empty( $custom_taxonomies ) ) {
+		if (!empty($custom_taxonomies)) {
 
-			foreach ( $custom_taxonomies as $taxon ) {
+			foreach ($custom_taxonomies as $taxon) {
 
 				// translators: %s: Taxonomy name.
-				$this->log( sprintf( '+ ' . __( "Purging custom taxonomy '%s'", 'nginx-helper' ), $taxon ) );
+				$this->log(sprintf('+ ' . __("Purging custom taxonomy '%s'", 'nginx-helper'), $taxon));
 
-				if ( ! in_array( $taxon, array( 'category', 'post_tag', 'link_category' ), true ) ) {
+				if (!in_array($taxon, array('category', 'post_tag', 'link_category'), true)) {
 
-					$terms = get_terms( $taxon );
+					$terms = get_terms($taxon);
 
-					if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+					if (!is_wp_error($terms) && !empty($terms)) {
 
-						foreach ( $terms as $term ) {
+						foreach ($terms as $term) {
 
-							$this->purge_url( get_term_link( $term, $taxon ) );
-
+							$this->purge_url(get_term_link($term, $taxon));
 						}
 					}
 				} else {
 					// translators: %s: Taxonomy name.
-					$this->log( sprintf( '- ' . esc_html__( "Your built-in taxonomy '%s' has param '_builtin' set to false.", 'nginx-helper' ), $taxon ), 'WARNING' );
+					$this->log(sprintf('- ' . esc_html__("Your built-in taxonomy '%s' has param '_builtin' set to false.", 'nginx-helper'), $taxon), 'WARNING');
 				}
 			}
 		} else {
-			$this->log( '- ' . __( 'No custom taxonomies', 'nginx-helper' ) );
+			$this->log('- ' . __('No custom taxonomies', 'nginx-helper'));
 		}
 
 		return true;
@@ -935,7 +923,8 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_all_taxonomies() {
+	private function _purge_all_taxonomies()
+	{
 
 		$this->_purge_all_categories();
 		$this->_purge_all_posttags();
@@ -949,9 +938,10 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_all_posts() {
+	private function _purge_all_posts()
+	{
 
-		$this->log( __( 'Purging all posts, pages and custom post types.', 'nginx-helper' ) );
+		$this->log(__('Purging all posts, pages and custom post types.', 'nginx-helper'));
 
 		$args = array(
 			'posts_per_page' => 0,
@@ -960,22 +950,20 @@ abstract class Purger {
 		);
 
 		$get_posts = new WP_Query();
-		$_posts    = $get_posts->query( $args );
+		$_posts    = $get_posts->query($args);
 
-		if ( ! empty( $_posts ) ) {
+		if (!empty($_posts)) {
 
-			foreach ( $_posts as $p ) {
+			foreach ($_posts as $p) {
 
-				$this->log( sprintf( '+ ' . __( "Purging post id '%1\$d' ( post type '%2\$s' )", 'nginx-helper' ), $p->ID, $p->post_type ) );
-				$this->purge_url( get_permalink( $p->ID ) );
-
+				$this->log(sprintf('+ ' . __("Purging post id '%1\$d' ( post type '%2\$s' )", 'nginx-helper'), $p->ID, $p->post_type));
+				$this->purge_url(get_permalink($p->ID));
 			}
 		} else {
-			$this->log( '- ' . __( 'No posts', 'nginx-helper' ) );
+			$this->log('- ' . __('No posts', 'nginx-helper'));
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -983,26 +971,27 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	private function _purge_all_date_archives() {
+	private function _purge_all_date_archives()
+	{
 
-		$this->log( __( 'Purging all date-based archives.', 'nginx-helper' ) );
+		$this->log(__('Purging all date-based archives.', 'nginx-helper'));
 
 		$this->_purge_all_daily_archives();
 		$this->_purge_all_monthly_archives();
 		$this->_purge_all_yearly_archives();
 
 		return true;
-
 	}
 
 	/**
 	 * Purge daily archives cache.
 	 */
-	private function _purge_all_daily_archives() {
+	private function _purge_all_daily_archives()
+	{
 
 		global $wpdb;
 
-		$this->log( __( 'Purging all daily archives.', 'nginx-helper' ) );
+		$this->log(__('Purging all daily archives.', 'nginx-helper'));
 
 		$_query_daily_archives = $wpdb->prepare(
 			"SELECT YEAR(post_date) AS %s, MONTH(post_date) AS %s, DAYOFMONTH(post_date) AS %s, count(ID) as posts
@@ -1017,42 +1006,41 @@ abstract class Purger {
 			'publish'
 		);
 
-		$_daily_archives = $wpdb->get_results( $_query_daily_archives ); // phpcs:ignore
+		$_daily_archives = $wpdb->get_results($_query_daily_archives); // phpcs:ignore
 
-		if ( ! empty( $_daily_archives ) ) {
+		if (!empty($_daily_archives)) {
 
-			foreach ( $_daily_archives as $_da ) {
+			foreach ($_daily_archives as $_da) {
 
 				$this->log(
 					sprintf(
-						'+ ' . __( "Purging daily archive '%1\$s/%2\$s/%3\$s'", 'nginx-helper' ),
+						'+ ' . __("Purging daily archive '%1\$s/%2\$s/%3\$s'", 'nginx-helper'),
 						$_da->year,
 						$_da->month,
 						$_da->dayofmonth
 					)
 				);
 
-				$this->purge_url( get_day_link( $_da->year, $_da->month, $_da->dayofmonth ) );
-
+				$this->purge_url(get_day_link($_da->year, $_da->month, $_da->dayofmonth));
 			}
 		} else {
-			$this->log( '- ' . __( 'No daily archives', 'nginx-helper' ) );
+			$this->log('- ' . __('No daily archives', 'nginx-helper'));
 		}
-
 	}
 
 	/**
 	 * Purge all monthly archives.
 	 */
-	private function _purge_all_monthly_archives() {
+	private function _purge_all_monthly_archives()
+	{
 
 		global $wpdb;
 
-		$this->log( __( 'Purging all monthly archives.', 'nginx-helper' ) );
+		$this->log(__('Purging all monthly archives.', 'nginx-helper'));
 
-		$_monthly_archives = wp_cache_get( 'nginx_helper_monthly_archives', 'nginx_helper' );
+		$_monthly_archives = wp_cache_get('nginx_helper_monthly_archives', 'nginx_helper');
 
-		if ( empty( $_monthly_archives ) ) {
+		if (empty($_monthly_archives)) {
 
 			$_query_monthly_archives = $wpdb->prepare(
 				"SELECT YEAR(post_date) AS %s, MONTH(post_date) AS %s, count(ID) as posts
@@ -1066,38 +1054,36 @@ abstract class Purger {
 				'publish'
 			);
 
-			$_monthly_archives = $wpdb->get_results( $_query_monthly_archives ); // phpcs:ignore
+			$_monthly_archives = $wpdb->get_results($_query_monthly_archives); // phpcs:ignore
 
-			wp_cache_set( 'nginx_helper_monthly_archives', $_monthly_archives, 'nginx_helper', 24 * 60 * 60 );
-
+			wp_cache_set('nginx_helper_monthly_archives', $_monthly_archives, 'nginx_helper', 24 * 60 * 60);
 		}
 
-		if ( ! empty( $_monthly_archives ) ) {
+		if (!empty($_monthly_archives)) {
 
-			foreach ( $_monthly_archives as $_ma ) {
+			foreach ($_monthly_archives as $_ma) {
 
-				$this->log( sprintf( '+ ' . __( "Purging monthly archive '%1\$s/%2\$s'", 'nginx-helper' ), $_ma->year, $_ma->month ) );
-				$this->purge_url( get_month_link( $_ma->year, $_ma->month ) );
-
+				$this->log(sprintf('+ ' . __("Purging monthly archive '%1\$s/%2\$s'", 'nginx-helper'), $_ma->year, $_ma->month));
+				$this->purge_url(get_month_link($_ma->year, $_ma->month));
 			}
 		} else {
-			$this->log( '- ' . __( 'No monthly archives', 'nginx-helper' ) );
+			$this->log('- ' . __('No monthly archives', 'nginx-helper'));
 		}
-
 	}
 
 	/**
 	 * Purge all yearly archive cache.
 	 */
-	private function _purge_all_yearly_archives() {
+	private function _purge_all_yearly_archives()
+	{
 
 		global $wpdb;
 
-		$this->log( __( 'Purging all yearly archives.', 'nginx-helper' ) );
+		$this->log(__('Purging all yearly archives.', 'nginx-helper'));
 
-		$_yearly_archives = wp_cache_get( 'nginx_helper_yearly_archives', 'nginx_helper' );
+		$_yearly_archives = wp_cache_get('nginx_helper_yearly_archives', 'nginx_helper');
 
-		if ( empty( $_yearly_archives ) ) {
+		if (empty($_yearly_archives)) {
 
 			$_query_yearly_archives = $wpdb->prepare(
 				"SELECT YEAR(post_date) AS %s, count(ID) as posts
@@ -1110,25 +1096,22 @@ abstract class Purger {
 				'publish'
 			);
 
-			$_yearly_archives = $wpdb->get_results( $_query_yearly_archives ); // phpcs:ignore
+			$_yearly_archives = $wpdb->get_results($_query_yearly_archives); // phpcs:ignore
 
-			wp_cache_set( 'nginx_helper_yearly_archives', $_yearly_archives, 'nginx_helper', 24 * 60 * 60 );
-
+			wp_cache_set('nginx_helper_yearly_archives', $_yearly_archives, 'nginx_helper', 24 * 60 * 60);
 		}
 
-		if ( ! empty( $_yearly_archives ) ) {
+		if (!empty($_yearly_archives)) {
 
-			foreach ( $_yearly_archives as $_ya ) {
+			foreach ($_yearly_archives as $_ya) {
 
 				// translators: %s: Year to purge cache.
-				$this->log( sprintf( '+ ' . esc_html__( "Purging yearly archive '%s'", 'nginx-helper' ), $_ya->year ) );
-				$this->purge_url( get_year_link( $_ya->year ) );
-
+				$this->log(sprintf('+ ' . esc_html__("Purging yearly archive '%s'", 'nginx-helper'), $_ya->year));
+				$this->purge_url(get_year_link($_ya->year));
 			}
 		} else {
-			$this->log( '- ' . __( 'No yearly archives', 'nginx-helper' ) );
+			$this->log('- ' . __('No yearly archives', 'nginx-helper'));
 		}
-
 	}
 
 	/**
@@ -1136,18 +1119,18 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	public function purge_them_all() {
+	public function purge_them_all()
+	{
 
-		$this->log( __( "Let's purge everything!", 'nginx-helper' ) );
+		$this->log(__("Let's purge everything!", 'nginx-helper'));
 		$this->_purge_homepage();
 		$this->_purge_personal_urls();
 		$this->_purge_all_posts();
 		$this->_purge_all_taxonomies();
 		$this->_purge_all_date_archives();
-		$this->log( __( 'Everything purged!', 'nginx-helper' ) );
+		$this->log(__('Everything purged!', 'nginx-helper'));
 
 		return true;
-
 	}
 
 	/**
@@ -1159,33 +1142,31 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	public function purge_on_term_taxonomy_edited( $term_id, $tt_id, $taxon ) {
+	public function purge_on_term_taxonomy_edited($term_id, $tt_id, $taxon)
+	{
 
 		global $nginx_helper_admin;
 
-		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+		if (!$nginx_helper_admin->options['enable_purge']) {
 			return;
 		}
 
-		$this->log( __( 'Term taxonomy edited or deleted', 'nginx-helper' ) );
+		$this->log(__('Term taxonomy edited or deleted', 'nginx-helper'));
 
-		$term           = get_term( $term_id, $taxon );
+		$term           = get_term($term_id, $taxon);
 		$current_filter = current_filter();
 
-		if ( 'edit_term' === $current_filter && ! is_wp_error( $term ) && ! empty( $term ) ) {
+		if ('edit_term' === $current_filter && !is_wp_error($term) && !empty($term)) {
 
-			$this->log( sprintf( __( "Term taxonomy '%1\$s' edited, (tt_id '%2\$d', term_id '%3\$d', taxonomy '%4\$s')", 'nginx-helper' ), $term->name, $tt_id, $term_id, $taxon ) );
+			$this->log(sprintf(__("Term taxonomy '%1\$s' edited, (tt_id '%2\$d', term_id '%3\$d', taxonomy '%4\$s')", 'nginx-helper'), $term->name, $tt_id, $term_id, $taxon));
+		} elseif ('delete_term' === $current_filter) {
 
-		} elseif ( 'delete_term' === $current_filter ) {
-
-			$this->log( sprintf( __( "A term taxonomy has been deleted from taxonomy '%1\$s', (tt_id '%2\$d', term_id '%3\$d')", 'nginx-helper' ), $taxon, $term_id, $tt_id ) );
-
+			$this->log(sprintf(__("A term taxonomy has been deleted from taxonomy '%1\$s', (tt_id '%2\$d', term_id '%3\$d')", 'nginx-helper'), $taxon, $term_id, $tt_id));
 		}
 
 		$this->_purge_homepage();
 
 		return true;
-
 	}
 
 	/**
@@ -1195,28 +1176,27 @@ abstract class Purger {
 	 *
 	 * @return bool
 	 */
-	public function purge_on_check_ajax_referer( $action ) {
+	public function purge_on_check_ajax_referer($action)
+	{
 
 		global $nginx_helper_admin;
 
-		if ( ! $nginx_helper_admin->options['enable_purge'] ) {
+		if (!$nginx_helper_admin->options['enable_purge']) {
 			return;
 		}
 
-		switch ( $action ) {
+		switch ($action) {
 
 			case 'save-sidebar-widgets':
-				$this->log( __( 'Widget saved, moved or removed in a sidebar', 'nginx-helper' ) );
+				$this->log(__('Widget saved, moved or removed in a sidebar', 'nginx-helper'));
 				$this->_purge_homepage();
 				break;
 
 			default:
 				break;
-
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -1228,35 +1208,49 @@ abstract class Purger {
 	 *
 	 * @return void
 	 */
-	public function unlink_recursive( $dir, $delete_root_too ) {
+	public function unlink_recursive($dir, $delete_root_too)
+	{
+		$this->log($dir);
 
-		if ( ! is_dir( $dir ) ) {
+		if (!is_dir($dir)) {
+			$this->log("{$dir} is not available. Stopping.");
 			return;
 		}
 
-		$dh = opendir( $dir );
+		$dh = opendir($dir);
 
-		if ( ! $dh ) {
+		if (!$dh) {
+			$this->log("{$dir} resource not available. Stopping.");
 			return;
 		}
 
 		// phpcs:ignore -- WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- Variable assignment required for recursion.
-		while ( false !== ( $obj = readdir( $dh ) ) ) {
+		while (false !== ($obj = readdir($dh))) {
 
-			if ( '.' === $obj || '..' === $obj ) {
+			if ('.' === $obj || '..' === $obj) {
 				continue;
 			}
 
-			if ( ! @unlink( $dir . '/' . $obj ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-				$this->unlink_recursive( $dir . '/' . $obj, false );
+			if (!@unlink($dir . '/' . $obj)) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				$this->unlink_recursive($dir . '/' . $obj, false);
 			}
 		}
 
-		if ( $delete_root_too ) {
-			rmdir( $dir );
+		if ($delete_root_too) {
+			rmdir($dir);
 		}
 
-		closedir( $dh );
+		closedir($dh);
 	}
 
+	public function run_cron_unlink_recursive($dir, $delete_root_too)
+	{
+		$this->log('* * * * *');
+		$this->log('* Starting to purge everything..');
+
+		$this->unlink_recursive($dir, $delete_root_too);
+
+		$this->log('* Purged Everything done.');
+		$this->log('* * * * *');
+	}
 }


### PR DESCRIPTION
I have a multisite blog and the cache is quite large due to the number of traffic and contents.

I have been facing the error in Nginx as below:

> 2024/03/31 12:36:26 [error] 2028878#2028878: *201901 upstream sent too big header while reading response header from upstream, client: 113.211.208.12, server: domain.com, request: "GET /wp/wp-admin/network/settings.php?page=nginx&nginx_helper_action=purge&nginx_helper_urls=all&_wpnonce=08e9fbc39c HTTP/2.0", upstream: "fastcgi://unix:/run/php/php8.2-fpm.sock:", host: "domain.com", referrer: "https://domain.com/wp/wp-admin/network/settings.php?page=nginx&nginx_helper_action=purge&nginx_helper_urls=all&_wpnonce=08e9fbc39c"

And changing the Nginx `fastcgi_buffers` and `fastcgi_buffer_size` does not seems to solve the issue. Hence, I went deep into the plugin to see where does this came from.

Apparently, on the request to "Purge Entire Cache", the GET request execute the `purge_all` method in `FastCGI_Purger class`. Then, in that method is runs `$this->unlink_recursive()`. This seems to produce huge response buffer.

I decided to offload that process to Cron, using `wp_schedule_single_event`.