### PR TITLE
GH-333: Fatal Error on Empty Redis Port Setting in Nginx Helper Plugin [Develop]

### DIFF
--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -61,14 +61,21 @@ if ( isset( $all_inputs['smart_http_expire_save'] ) && wp_verify_nonce( $all_inp
 
     $site_options = get_site_option( 'rt_wp_nginx_helper_options', array() );
 
-    // Uncheck checkbox fields whose default value is `1` but user has unchecked.
     foreach ( $nginx_helper_admin->nginx_helper_default_settings() as $default_setting_field => $default_setting_value ) {
 
+	    // Uncheck checkbox fields whose default value is `1` but user has unchecked.
         if ( 1 === $default_setting_value && isset( $site_options[ $default_setting_field ] ) && empty( $all_inputs[ $default_setting_field ] ) ) {
 
 	        $nginx_settings[ $default_setting_field ] = 0;
 
         }
+
+        // Populate the setting field with default value when it is empty.
+	    if ( '' === $nginx_settings[ $default_setting_field ] ) {
+
+		    $nginx_settings[ $default_setting_field ] = $default_setting_value;
+
+	    }
     }
 
 	if ( ( ! is_numeric( $nginx_settings['log_filesize'] ) ) || ( empty( $nginx_settings['log_filesize'] ) ) ) {

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -59,24 +59,24 @@ if ( isset( $all_inputs['smart_http_expire_save'] ) && wp_verify_nonce( $all_inp
 		$nginx_helper_admin->nginx_helper_default_settings()
 	);
 
-    $site_options = get_site_option( 'rt_wp_nginx_helper_options', array() );
+	$site_options = get_site_option( 'rt_wp_nginx_helper_options', array() );
 
-    foreach ( $nginx_helper_admin->nginx_helper_default_settings() as $default_setting_field => $default_setting_value ) {
+	foreach ( $nginx_helper_admin->nginx_helper_default_settings() as $default_setting_field => $default_setting_value ) {
 
-	    // Uncheck checkbox fields whose default value is `1` but user has unchecked.
-        if ( 1 === $default_setting_value && isset( $site_options[ $default_setting_field ] ) && empty( $all_inputs[ $default_setting_field ] ) ) {
+		// Uncheck checkbox fields whose default value is `1` but user has unchecked.
+		if ( 1 === $default_setting_value && isset( $site_options[ $default_setting_field ] ) && empty( $all_inputs[ $default_setting_field ] ) ) {
 
-	        $nginx_settings[ $default_setting_field ] = 0;
+			$nginx_settings[ $default_setting_field ] = 0;
 
-        }
+		}
 
-        // Populate the setting field with default value when it is empty.
-	    if ( '' === $nginx_settings[ $default_setting_field ] ) {
+		// Populate the setting field with default value when it is empty.
+		if ( '' === $nginx_settings[ $default_setting_field ] ) {
 
-		    $nginx_settings[ $default_setting_field ] = $default_setting_value;
+			$nginx_settings[ $default_setting_field ] = $default_setting_value;
 
-	    }
-    }
+		}
+	}
 
 	if ( ( ! is_numeric( $nginx_settings['log_filesize'] ) ) || ( empty( $nginx_settings['log_filesize'] ) ) ) {
 		$error_log_filesize = __( 'Log file size must be a number.', 'nginx-helper' );


### PR DESCRIPTION
## Description
- This PR adds functionality to re-populate the empty text input fields with their default values at the time of save. 
- This will ensure that we will never have any empty text input field & will never get a fatal error due to an empty text input field.

## Fixes/Covers
- https://github.com/rtCamp/nginx-helper/issues/333
