### PR TITLE
Add Filter to get the cache path for Nginx

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -276,11 +276,14 @@ class Nginx_Helper_Admin {
 			'redis_hostname'                   => '127.0.0.1',
 			'redis_port'                       => '6379',
 			'redis_prefix'                     => 'nginx-cache:',
+            'redis_unix_socket'                => '',
             'redis_database'                   => 0,
             'redis_username'                   => '',
             'redis_password'                   => '',
 			'purge_url'                        => '',
 			'redis_enabled_by_constant'        => 0,
+            'redis_socket_enabled_by_constant' => 0,
+            'redis_acl_enabled_by_constant'    => 0,
 		);
 
 	}
@@ -312,18 +315,24 @@ class Nginx_Helper_Admin {
 			defined( 'RT_WP_NGINX_HELPER_REDIS_PORT' ) &&
 			defined( 'RT_WP_NGINX_HELPER_REDIS_PREFIX' )
 		);
+		
+		$data['redis_acl_enabled_by_constant']    = defined('RT_WP_NGINX_HELPER_REDIS_USERNAME') && defined('RT_WP_NGINX_HELPER_REDIS_PASSWORD');
+		$data['redis_socket_enabled_by_constant'] = defined('RT_WP_NGINX_HELPER_REDIS_UNIX_SOCKET');
+		$data['redis_unix_socket']                = $data['redis_socket_enabled_by_constant'] ? RT_WP_NGINX_HELPER_REDIS_UNIX_SOCKET : $data['redis_unix_socket'];
+		$data['redis_username']                   = $data['redis_acl_enabled_by_constant'] ? RT_WP_NGINX_HELPER_REDIS_USERNAME : $data['redis_username'];
+		$data['redis_password']                   = $data['redis_acl_enabled_by_constant'] ? RT_WP_NGINX_HELPER_REDIS_PASSWORD : $data['redis_password'];
 
 		if ( ! $is_redis_enabled ) {
 			return $data;
 		}
 
-		$data['redis_enabled_by_constant'] = $is_redis_enabled;
-		$data['enable_purge']              = $is_redis_enabled;
-		$data['cache_method']              = 'enable_redis';
-		$data['redis_hostname']            = RT_WP_NGINX_HELPER_REDIS_HOSTNAME;
-		$data['redis_port']                = RT_WP_NGINX_HELPER_REDIS_PORT;
-		$data['redis_prefix']              = RT_WP_NGINX_HELPER_REDIS_PREFIX;
-        $data['redis_database']            = defined('RT_WP_NGINX_HELPER_REDIS_DATABASE') ? RT_WP_NGINX_HELPER_REDIS_DATABASE : 0;
+		$data['redis_enabled_by_constant']        = $is_redis_enabled;
+		$data['enable_purge']                     = $is_redis_enabled;
+		$data['cache_method']                     = 'enable_redis';
+		$data['redis_hostname']                   = RT_WP_NGINX_HELPER_REDIS_HOSTNAME;
+		$data['redis_port']                       = RT_WP_NGINX_HELPER_REDIS_PORT;
+		$data['redis_prefix']                     = RT_WP_NGINX_HELPER_REDIS_PREFIX;
+        $data['redis_database']                   = defined('RT_WP_NGINX_HELPER_REDIS_DATABASE') ? RT_WP_NGINX_HELPER_REDIS_DATABASE : 0;
 
 		return $data;
 

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -277,6 +277,8 @@ class Nginx_Helper_Admin {
 			'redis_port'                       => '6379',
 			'redis_prefix'                     => 'nginx-cache:',
             'redis_database'                   => 0,
+            'redis_username'                   => '',
+            'redis_password'                   => '',
 			'purge_url'                        => '',
 			'redis_enabled_by_constant'        => 0,
 		);

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -276,6 +276,7 @@ class Nginx_Helper_Admin {
 			'redis_hostname'                   => '127.0.0.1',
 			'redis_port'                       => '6379',
 			'redis_prefix'                     => 'nginx-cache:',
+            'redis_database'                   => 0,
 			'purge_url'                        => '',
 			'redis_enabled_by_constant'        => 0,
 		);
@@ -295,6 +296,7 @@ class Nginx_Helper_Admin {
 				'redis_hostname' => '127.0.0.1',
 				'redis_port'     => '6379',
 				'redis_prefix'   => 'nginx-cache:',
+                'redis_database' => 0,
 			)
 		);
 
@@ -319,6 +321,7 @@ class Nginx_Helper_Admin {
 		$data['redis_hostname']            = RT_WP_NGINX_HELPER_REDIS_HOSTNAME;
 		$data['redis_port']                = RT_WP_NGINX_HELPER_REDIS_PORT;
 		$data['redis_prefix']              = RT_WP_NGINX_HELPER_REDIS_PREFIX;
+        $data['redis_database']            = defined('RT_WP_NGINX_HELPER_REDIS_DATABASE') ? RT_WP_NGINX_HELPER_REDIS_DATABASE : 0;
 
 		return $data;
 

--- a/admin/class-phpredis-purger.php
+++ b/admin/class-phpredis-purger.php
@@ -39,10 +39,24 @@ class PhpRedis_Purger extends Purger {
 		try {
 
 			$this->redis_object = new Redis();
+			
+			$redis_acl = array();
+			
+			$username = $nginx_helper_admin->options['redis_username'];
+			$password = $nginx_helper_admin->options['redis_password'];
+			
+			if( $username && $password ) {
+				$redis_acl['auth'] = array( $username, $password );
+			}
+			
 			$this->redis_object->connect(
 				$nginx_helper_admin->options['redis_hostname'],
 				$nginx_helper_admin->options['redis_port'],
-				5
+				5,
+				null,
+				0,
+				0,
+				$redis_acl
 			);
 			
 			if( $nginx_helper_admin->options['redis_database'] !== 0 ) {

--- a/admin/class-phpredis-purger.php
+++ b/admin/class-phpredis-purger.php
@@ -49,9 +49,12 @@ class PhpRedis_Purger extends Purger {
 				$redis_acl['auth'] = array( $username, $password );
 			}
 			
+			$hostname = empty( $nginx_helper_admin->options['redis_unix_socket'] ) ? $nginx_helper_admin->options['redis_hostname'] : $nginx_helper_admin->options['redis_unix_socket'];
+			$port     = empty( $nginx_helper_admin->options['redis_unix_socket'] ) ? $nginx_helper_admin->options['redis_port'] : 0;
+			
 			$this->redis_object->connect(
-				$nginx_helper_admin->options['redis_hostname'],
-				$nginx_helper_admin->options['redis_port'],
+				$hostname,
+				$port,
 				5,
 				null,
 				0,

--- a/admin/class-phpredis-purger.php
+++ b/admin/class-phpredis-purger.php
@@ -44,6 +44,10 @@ class PhpRedis_Purger extends Purger {
 				$nginx_helper_admin->options['redis_port'],
 				5
 			);
+			
+			if( $nginx_helper_admin->options['redis_database'] !== 0 ) {
+				$this->redis_object->select($nginx_helper_admin->options['redis_database']);
+			}
 
 		} catch ( Exception $e ) {
 			$this->log( $e->getMessage(), 'ERROR' );

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -37,12 +37,17 @@ class Predis_Purger extends Purger {
 		}
 
 		Predis\Autoloader::register();
+		
+		$username = $nginx_helper_admin->options['redis_username'];
+		$password = $nginx_helper_admin->options['redis_password'];
 
 		// redis server parameter.
 		$this->redis_object = new Predis\Client(
 			array(
 				'host' => $nginx_helper_admin->options['redis_hostname'],
 				'port' => $nginx_helper_admin->options['redis_port'],
+				'username' => $username,
+				'password' => $password,
 			)
 		);
 		

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -41,8 +41,9 @@ class Predis_Purger extends Purger {
 		// redis server parameter.
 		$this->redis_object = new Predis\Client(
 			array(
-				'host' => $nginx_helper_admin->options['redis_hostname'],
-				'port' => $nginx_helper_admin->options['redis_port'],
+				'host'     => $nginx_helper_admin->options['redis_hostname'],
+				'port'     => $nginx_helper_admin->options['redis_port'],
+				'database' => $nginx_helper_admin->options['redis_database'],
 			)
 		);
 

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -41,11 +41,14 @@ class Predis_Purger extends Purger {
 		// redis server parameter.
 		$this->redis_object = new Predis\Client(
 			array(
-				'host'     => $nginx_helper_admin->options['redis_hostname'],
-				'port'     => $nginx_helper_admin->options['redis_port'],
-				'database' => $nginx_helper_admin->options['redis_database'],
+				'host' => $nginx_helper_admin->options['redis_hostname'],
+				'port' => $nginx_helper_admin->options['redis_port'],
 			)
 		);
+		
+		if( $nginx_helper_admin->options['redis_database'] !== 0 ) {
+			$this->redis_object->select($nginx_helper_admin->options['redis_database']);
+		}
 
 		try {
 			$this->redis_object->connect();

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -38,18 +38,25 @@ class Predis_Purger extends Purger {
 
 		Predis\Autoloader::register();
 		
+		$predis_args = array();
+		
 		$username = $nginx_helper_admin->options['redis_username'];
 		$password = $nginx_helper_admin->options['redis_password'];
-
+		
+		if( empty( $nginx_helper_admin->options['redis_unix_socket'] ) ) {
+			$predis_args['path'] = $nginx_helper_admin->options['redis_unix_socket'];
+		} else {
+			$predis_args['host'] = $nginx_helper_admin->options['redis_hostname'];;
+			$predis_args['port'] = $nginx_helper_admin->options['redis_port'];
+		}
+		
+		if ( $username && $password ) {
+			$predis_args['username'] = $username;
+			$predis_args['password'] = $password;
+		}
+		
 		// redis server parameter.
-		$this->redis_object = new Predis\Client(
-			array(
-				'host' => $nginx_helper_admin->options['redis_hostname'],
-				'port' => $nginx_helper_admin->options['redis_port'],
-				'username' => $username,
-				'password' => $password,
-			)
-		);
+		$this->redis_object = new Predis\Client( $predis_args );
 		
 		if( $nginx_helper_admin->options['redis_database'] !== 0 ) {
 			$this->redis_object->select($nginx_helper_admin->options['redis_database']);

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -22,6 +22,7 @@ $args = array(
 	'redis_hostname',
 	'redis_port',
 	'redis_prefix',
+    'redis_database',
 	'purge_homepage_on_edit',
 	'purge_homepage_on_del',
 	'purge_url',
@@ -288,6 +289,21 @@ if ( is_multisite() ) {
 								?>
 							</td>
 						</tr>
+                        <tr>
+                            <th><label for="redis_database"><?php esc_html_e( 'Database', 'nginx-helper' ); ?></label></th>
+                            <td>
+                                <input id="redis_database" class="medium-text" type="text" name="redis_database" value="<?php echo esc_attr( $nginx_helper_settings['redis_database'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
+								<?php
+								if ( $nginx_helper_settings['redis_enabled_by_constant'] ) {
+									
+									echo '<p class="description">';
+									esc_html_e( 'Overridden by constant variables.', 'nginx-helper' );
+									echo '</p>';
+									
+								}
+								?>
+                            </td>
+                        </tr>
 					</table>
 				</div> <!-- End of .inside -->
 			</div>

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -23,6 +23,8 @@ $args = array(
 	'redis_port',
 	'redis_prefix',
     'redis_database',
+    'redis_username',
+    'redis_password',
 	'purge_homepage_on_edit',
 	'purge_homepage_on_del',
 	'purge_url',
@@ -293,6 +295,38 @@ if ( is_multisite() ) {
                             <th><label for="redis_database"><?php esc_html_e( 'Database', 'nginx-helper' ); ?></label></th>
                             <td>
                                 <input id="redis_database" class="medium-text" type="text" name="redis_database" value="<?php echo esc_attr( $nginx_helper_settings['redis_database'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
+								<?php
+								if ( $nginx_helper_settings['redis_enabled_by_constant'] ) {
+									
+									echo '<p class="description">';
+									esc_html_e( 'Overridden by constant variables.', 'nginx-helper' );
+									echo '</p>';
+									
+								}
+								?>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <th><label for="redis_username"><?php esc_html_e( 'Username:', 'nginx-helper' ); ?></label></th>
+                            <td>
+                                <input id="redis_username" class="medium-text" type="text" name="redis_username" value="<?php echo esc_attr( $nginx_helper_settings['redis_username'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
+								<?php
+								if ( $nginx_helper_settings['redis_enabled_by_constant'] ) {
+									
+									echo '<p class="description">';
+									esc_html_e( 'Overridden by constant variables.', 'nginx-helper' );
+									echo '</p>';
+									
+								}
+								?>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <th><label for="redis_password"><?php esc_html_e( 'Password:', 'nginx-helper' ); ?></label></th>
+                            <td>
+                                <input id="redis_password" class="medium-text" type="text" name="redis_password" value="<?php echo esc_attr( $nginx_helper_settings['redis_password'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
 								<?php
 								if ( $nginx_helper_settings['redis_enabled_by_constant'] ) {
 									

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -25,6 +25,9 @@ $args = array(
     'redis_database',
     'redis_username',
     'redis_password',
+    'redis_unix_socket',
+    'redis_socket_enabled_by_constant',
+    'redis_acl_enabled_by_constant',
 	'purge_homepage_on_edit',
 	'purge_homepage_on_del',
 	'purge_url',
@@ -249,7 +252,7 @@ if ( is_multisite() ) {
 						<tr>
 							<th><label for="redis_hostname"><?php esc_html_e( 'Hostname', 'nginx-helper' ); ?></label></th>
 							<td>
-								<input id="redis_hostname" class="medium-text" type="text" name="redis_hostname" value="<?php echo esc_attr( $nginx_helper_settings['redis_hostname'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
+								<input id="redis_hostname" class="medium-text" type="text" name="redis_hostname" value="<?php echo esc_attr( $nginx_helper_settings['redis_hostname'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] || $nginx_helper_settings['redis_unix_socket'] ) ? 'readonly="readonly"' : ''; ?> />
 								<?php
 								if ( $nginx_helper_settings['redis_enabled_by_constant'] ) {
 
@@ -257,6 +260,13 @@ if ( is_multisite() ) {
 									esc_html_e( 'Overridden by constant variables.', 'nginx-helper' );
 									echo '</p>';
 
+								}
+								?>
+								<?php
+								if ( $nginx_helper_settings['redis_unix_socket'] ) {
+									echo '<p class="description">';
+									esc_html_e( 'Overridden by unix socket path.', 'nginx-helper' );
+									echo '</p>';
 								}
 								?>
 							</td>
@@ -264,7 +274,7 @@ if ( is_multisite() ) {
 						<tr>
 							<th><label for="redis_port"><?php esc_html_e( 'Port', 'nginx-helper' ); ?></label></th>
 							<td>
-								<input id="redis_port" class="medium-text" type="text" name="redis_port" value="<?php echo esc_attr( $nginx_helper_settings['redis_port'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
+								<input id="redis_port" class="medium-text" type="text" name="redis_port" value="<?php echo esc_attr( $nginx_helper_settings['redis_port'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] || $nginx_helper_settings['redis_unix_socket'] ) ? 'readonly="readonly"' : ''; ?> />
 								<?php
 								if ( $nginx_helper_settings['redis_enabled_by_constant'] ) {
 
@@ -274,8 +284,32 @@ if ( is_multisite() ) {
 
 								}
 								?>
+								<?php
+								if ( $nginx_helper_settings['redis_unix_socket'] ) {
+									
+									echo '<p class="description">';
+									esc_html_e( 'Overridden by unix socket path.', 'nginx-helper' );
+									echo '</p>';
+									
+								}
+								?>
 							</td>
 						</tr>
+                        <tr>
+                            <th><label for="redis_unix_socket"><?php esc_html_e( 'Socket Path', 'nginx-helper' ); ?></label></th>
+                            <td>
+                                <input id="redis_unix_socket" class="medium-text" type="text" name="redis_unix_socket" value="<?php echo esc_attr( $nginx_helper_settings['redis_unix_socket'] ); ?>" <?php echo ( $nginx_helper_settings['redis_socket_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
+								<?php
+								if ( $nginx_helper_settings['redis_socket_enabled_by_constant'] ) {
+									
+									echo '<p class="description">';
+									esc_html_e( 'Overridden by constant variables.', 'nginx-helper' );
+									echo '</p>';
+									
+								}
+								?>
+                            </td>
+                        </tr>
 						<tr>
 							<th><label for="redis_prefix"><?php esc_html_e( 'Prefix', 'nginx-helper' ); ?></label></th>
 							<td>
@@ -308,7 +342,7 @@ if ( is_multisite() ) {
                         </tr>
 
                         <tr>
-                            <th><label for="redis_username"><?php esc_html_e( 'Username:', 'nginx-helper' ); ?></label></th>
+                            <th><label for="redis_username"><?php esc_html_e( 'Username', 'nginx-helper' ); ?></label></th>
                             <td>
                                 <input id="redis_username" class="medium-text" type="text" name="redis_username" value="<?php echo esc_attr( $nginx_helper_settings['redis_username'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
 								<?php
@@ -324,7 +358,7 @@ if ( is_multisite() ) {
                         </tr>
 
                         <tr>
-                            <th><label for="redis_password"><?php esc_html_e( 'Password:', 'nginx-helper' ); ?></label></th>
+                            <th><label for="redis_password"><?php esc_html_e( 'Password', 'nginx-helper' ); ?></label></th>
                             <td>
                                 <input id="redis_password" class="medium-text" type="text" name="redis_password" value="<?php echo esc_attr( $nginx_helper_settings['redis_password'] ); ?>" <?php echo ( $nginx_helper_settings['redis_enabled_by_constant'] ) ? 'readonly="readonly"' : ''; ?> />
 								<?php

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -85,7 +85,8 @@ class Nginx_Helper {
 		}
 
 		if ( ! defined( 'RT_WP_NGINX_HELPER_CACHE_PATH' ) ) {
-			define( 'RT_WP_NGINX_HELPER_CACHE_PATH', '/var/run/nginx-cache' );
+            $cache_path = apply_filters( 'rt_wp_nginx_helper_cache_path', '/var/run/nginx-cache' );
+			define( 'RT_WP_NGINX_HELPER_CACHE_PATH', $cache_path  );
 		}
 
 		$this->load_dependencies();


### PR DESCRIPTION
## Description
The aim of this PR is to add a filter to read the cache path for nginx. It allows for setting custom paths for the plugin.

## Type
- New Feature

## Reference Issue
https://github.com/rtCamp/nginx-helper/issues/298

## Testing
The code has been tested locally and is working as expected.