### PR TITLE
Fix _load_textdomain_just_in_time notice in WordPress 6.7

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -78,6 +78,14 @@ class Nginx_Helper_Admin {
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
 		
+		$this->options = $this->nginx_helper_settings();
+	}
+	
+	/**
+	 * Initialize the settings tab.
+     * Required since i18n is used in the settings tab which can be invoked only after init hook since WordPress 6.7
+	 */
+	public function initialize_setting_tab() {
 		/**
 		 * Define settings tabs
 		 */
@@ -94,9 +102,8 @@ class Nginx_Helper_Admin {
 				),
 			)
 		);
-		
-		$this->options = $this->nginx_helper_settings();
 	}
+	
 	
 	/**
 	 * Register the stylesheets for the admin area.

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -104,7 +104,6 @@ class Nginx_Helper_Admin {
 			)
 		);
 	}
-
 	
 	/**
 	 * Register the stylesheets for the admin area.

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -104,7 +104,7 @@ class Nginx_Helper_Admin {
 			)
 		);
 	}
-	
+
 	
 	/**
 	 * Register the stylesheets for the admin area.

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -83,9 +83,10 @@ class Nginx_Helper_Admin {
 	
 	/**
 	 * Initialize the settings tab.
-     * Required since i18n is used in the settings tab which can be invoked only after init hook since WordPress 6.7
+	 * Required since i18n is used in the settings tab which can be invoked only after init hook since WordPress 6.7
 	 */
 	public function initialize_setting_tab() {
+		
 		/**
 		 * Define settings tabs
 		 */

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -169,7 +169,7 @@ class Nginx_Helper {
 		global $nginx_helper_admin, $nginx_purger;
 
 		$nginx_helper_admin = new Nginx_Helper_Admin( $this->get_plugin_name(), $this->get_version() );
-
+		$this->loader->add_action( 'init', $nginx_helper_admin, 'initialize_setting_tab' );
 		// Defines global variables.
 		if ( ! empty( $nginx_helper_admin->options['cache_method'] ) && 'enable_redis' === $nginx_helper_admin->options['cache_method'] ) {
 


### PR DESCRIPTION
## Description
The aim of this PR is to fix the warning in WordPress 6.7 since the i18n functions were being invoked before the init hook was fired.

## Type
- Bug Fix

## Reference Issue
- https://github.com/rtCamp/nginx-helper/issues/364

## Testing
- Upgrade your WordPress to version 6.7
- Open the Nginx Helper Options Page.
- Install a non-English language translation for the plugin.
- Set the site language as the one selected above.
- Once you are on admin dashboard, ensure that there are no warnings displayed.

Example to install a non-English Language:

`wp language plugin install nginx-helper ru_RU` // Install the Russian Language translation.
`wp user meta update 1 locale ru_RU` // Change the current user language to russian.
