### PR TITLE
Handle Predis Exception when Database is Out of Bounds.

### DIFF
--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -43,7 +43,7 @@ class Predis_Purger extends Purger {
 		$username = $nginx_helper_admin->options['redis_username'];
 		$password = $nginx_helper_admin->options['redis_password'];
 		
-		if( empty( $nginx_helper_admin->options['redis_unix_socket'] ) ) {
+		if( !empty( $nginx_helper_admin->options['redis_unix_socket'] ) ) {
 			$predis_args['path'] = $nginx_helper_admin->options['redis_unix_socket'];
 		} else {
 			$predis_args['host'] = $nginx_helper_admin->options['redis_hostname'];;

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -43,7 +43,7 @@ class Predis_Purger extends Purger {
 		$username = $nginx_helper_admin->options['redis_username'];
 		$password = $nginx_helper_admin->options['redis_password'];
 		
-		if( !empty( $nginx_helper_admin->options['redis_unix_socket'] ) ) {
+		if( ! empty( $nginx_helper_admin->options['redis_unix_socket'] ) ) {
 			$predis_args['path'] = $nginx_helper_admin->options['redis_unix_socket'];
 		} else {
 			$predis_args['host'] = $nginx_helper_admin->options['redis_hostname'];;
@@ -61,8 +61,8 @@ class Predis_Purger extends Purger {
 		try {
 			$this->redis_object->connect();
 			
-			if( $nginx_helper_admin->options['redis_database'] !== 0 ) {
-				$this->redis_object->select($nginx_helper_admin->options['redis_database']);
+			if( 0 !== $nginx_helper_admin->options['redis_database'] ) {
+				$this->redis_object->select( $nginx_helper_admin->options['redis_database'] );
 			}
 		} catch ( Exception $e ) {
 			$this->log( $e->getMessage(), 'ERROR' );

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -69,7 +69,6 @@ class Predis_Purger extends Purger {
 			return;
 		}
 		
-		
 
 	}
 

--- a/admin/class-predis-purger.php
+++ b/admin/class-predis-purger.php
@@ -60,14 +60,16 @@ class Predis_Purger extends Purger {
 
 		try {
 			$this->redis_object->connect();
+			
+			if( $nginx_helper_admin->options['redis_database'] !== 0 ) {
+				$this->redis_object->select($nginx_helper_admin->options['redis_database']);
+			}
 		} catch ( Exception $e ) {
 			$this->log( $e->getMessage(), 'ERROR' );
 			return;
 		}
 		
-		if( $nginx_helper_admin->options['redis_database'] !== 0 ) {
-			$this->redis_object->select($nginx_helper_admin->options['redis_database']);
-		}
+		
 
 	}
 


### PR DESCRIPTION
## Description
The aim of this PR is to handle the exception when the database number for Predis is out of bounds.

## Type
- Bug Fix

## Reference Issue
- https://github.com/rtCamp/nginx-helper/issues/350

## Testing
The code has been tested locally and is working as expected.