### PR TITLE
fix: FastCGI AMP purge when purge_method=unlink_files

### DIFF
--- a/admin/class-fastcgi-purger.php
+++ b/admin/class-fastcgi-purger.php
@@ -103,11 +103,13 @@ class FastCGI_Purger extends Purger {
 	 * @param string $url_base The base URL to purge.
 	 */
 	private function purge_amp_version( $url_base ) {
+		global $nginx_helper_admin;
+
 		$amp_url = sprintf( '%s/amp/', rtrim( $url_base, '/' ) );
 		
 		$this->log( '- Purging AMP URL | ' . $amp_url );
 		
-		if ( 'unlink_files' === $this->nginx_helper_admin->options['purge_method'] ) {
+		if ( 'unlink_files' === $nginx_helper_admin->options['purge_method'] ) {
 			$this->delete_cache_file_for( $amp_url );
 		} else {
 			$this->do_remote_get( $amp_url );


### PR DESCRIPTION
## Description
This PR resolves the issue #396.

Original PR - https://github.com/rtCamp/nginx-helper/pull/397