### PR TITLE
Fix typo in purge_url doc comment

### DIFF
--- a/admin/class-fastcgi-purger.php
+++ b/admin/class-fastcgi-purger.php
@@ -22,7 +22,7 @@ class FastCGI_Purger extends Purger {
 	 * Function to purge url.
 	 *
 	 * @param string $url URL.
-	 * @param bool   $feed Weather it is feed or not.
+	 * @param bool   $feed Whether it is feed or not.
 	 */
 	public function purge_url( $url, $feed = true ) {
 


### PR DESCRIPTION
update `Weather` to use `Whether` which seems more context-appropriate in the doc comment