### PR TITLE
Add a Filter to allow modifying the cache path for Nginx [Master]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nginx Helper #
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
-**Contributors:** rtcamp, rahul286, saurabhshukla, manishsongirkar36, faishal, desaiuditd, darren-slatten, jk3us, daankortenbach, telofy, pjv, llonchj, jinnko, weskoop, bcole808, gungeekatx, rohanveer, chandrapatel, gagan0123, ravanh, michaelbeil, samedwards, niwreg, entr, nuvoPoint, iam404, rittesh.patel, vishalkakadiya, BhargavBhandari90, bryant1410, 1gor, matt-h, dotsam, nathanielks, rigagoogoo, dslatten, jinschoi, kelin1003, vaishuagola27, rahulsprajapati, utkarshpatel, gsayed786, shashwatmittal, sudhiryadav, thrijith, stayallive, jaredwsmith, abhijitrakas, umeshnevase, sid177, souptik, arafatkn, subscriptiongroup, akrocks, vedantgandhi28, GridPane, stefanfisk
+**Contributors:** rtcamp, rahul286, saurabhshukla, manishsongirkar36, faishal, desaiuditd, darren-slatten, jk3us, daankortenbach, telofy, pjv, llonchj, jinnko, weskoop, bcole808, gungeekatx, rohanveer, chandrapatel, gagan0123, ravanh, michaelbeil, samedwards, niwreg, entr, nuvoPoint, iam404, rittesh.patel, vishalkakadiya, BhargavBhandari90, bryant1410, 1gor, matt-h, dotsam, nathanielks, rigagoogoo, dslatten, jinschoi, kelin1003, vaishuagola27, rahulsprajapati, utkarshpatel, gsayed786, shashwatmittal, sudhiryadav, thrijith, stayallive, jaredwsmith, abhijitrakas, umeshnevase, sid177, souptik, arafatkn, subscriptiongroup, akrocks, vedantgandhi28, GridPane, stefanfisk, SGr33n
 
 **Tags:** nginx, cache-purge, fastcgi, permalinks, redis-cache
 

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -85,7 +85,8 @@ class Nginx_Helper {
 		}
 
 		if ( ! defined( 'RT_WP_NGINX_HELPER_CACHE_PATH' ) ) {
-			define( 'RT_WP_NGINX_HELPER_CACHE_PATH', '/var/run/nginx-cache' );
+			$cache_path = apply_filters( 'rt_wp_nginx_helper_cache_path', '/var/run/nginx-cache' );
+			define( 'RT_WP_NGINX_HELPER_CACHE_PATH', $cache_path  );
 		}
 
 		$this->load_dependencies();

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Nginx Helper ===
 Contributors: rtcamp, rahul286, saurabhshukla, manishsongirkar36, faishal, desaiuditd, darren-slatten, jk3us, daankortenbach, telofy, pjv, llonchj, jinnko, weskoop, bcole808, gungeekatx, rohanveer, chandrapatel, gagan0123, ravanh, michaelbeil, samedwards, niwreg, entr, nuvoPoint, iam404, rittesh.patel, vishalkakadiya, BhargavBhandari90, bryant1410, 1gor, matt-h, dotsam, nathanielks, rigagoogoo, dslatten, jinschoi, kelin1003, vaishuagola27, rahulsprajapati, utkarshpatel, gsayed786, shashwatmittal, sudhiryadav, thrijith, stayallive, jaredwsmith, abhijitrakas, umeshnevase, sid177, souptik, arafatkn, subscriptiongroup, akrocks, vedantgandhi28, GridPane
-Unlinked Contributors: stefanfisk
+Unlinked Contributors: stefanfisk,SGr33n
 Donate Link: http://rt.cx/eedonate/
 Tags: nginx, cache-purge, fastcgi, permalinks, redis-cache
 License: GPLv2 or later (of-course)


### PR DESCRIPTION
## Description
The aim of this PR is to add a filter to read the cache path for nginx. It allows for setting custom paths for the plugin.

## Type
- New Feature

## Reference Issue
https://github.com/rtCamp/nginx-helper/issues/298

## Testing
The code has been tested locally and is working as expected.