### PR TITLE
Use the Nginx Helper | Purge cache capability to allow for purging from admin toolbar[Master]

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -209,7 +209,7 @@ class Nginx_Helper_Admin {
 	 */
 	public function nginx_helper_toolbar_purge_link( $wp_admin_bar ) {
 		
-		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'Nginx Helper | Purge cache' ) ) {
+		if ( ! current_user_can( 'Nginx Helper | Purge cache' ) ) {
 			return;
 		}
 		
@@ -770,7 +770,7 @@ class Nginx_Helper_Admin {
 			return;
 		}
 		
-		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'Nginx Helper | Purge cache' ) ) {
+		if ( ! current_user_can( 'Nginx Helper | Purge cache' ) ) {
 			wp_die( 'Sorry, you do not have the necessary privileges to edit these options.' );
 		}
 		

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -209,7 +209,7 @@ class Nginx_Helper_Admin {
 	 */
 	public function nginx_helper_toolbar_purge_link( $wp_admin_bar ) {
 		
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'Nginx Helper | Purge cache' ) ) {
 			return;
 		}
 		
@@ -770,7 +770,7 @@ class Nginx_Helper_Admin {
 			return;
 		}
 		
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'Nginx Helper | Purge cache' ) ) {
 			wp_die( 'Sorry, you do not have the necessary privileges to edit these options.' );
 		}
 		


### PR DESCRIPTION
### Description

This PR proposes using the existing `Nginx Helper | Purge Cache` capability to allow roles other than administrators to:

- Purge all cache
- Purge the cache of a specific page

These actions will be available via the admin toolbar.

- **Note:** This change does **not** grant the roles with the `Nginx Helper | Purge Cache` capability access to the Nginx Helper settings. It only enables the purge cache links in the admin toolbar.

### Related Issue

Proposed fix for (not final): #243 


![Screenshot at Jun 02 22-13-42](https://github.com/user-attachments/assets/f5c65fe1-33a9-4357-a8bc-4b4aef945a77)

![Screenshot at Jun 02 22-13-07](https://github.com/user-attachments/assets/887e0f5d-538c-4212-aebe-38781c9cb3a3)
