### PR TITLE
Fix Missing Purge Button on Admin Toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nginx Helper #
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
-**Contributors:** rtcamp, rahul286, saurabhshukla, manishsongirkar36, faishal, desaiuditd, darren-slatten, jk3us, daankortenbach, telofy, pjv, llonchj, jinnko, weskoop, bcole808, gungeekatx, rohanveer, chandrapatel, gagan0123, ravanh, michaelbeil, samedwards, niwreg, entr, nuvoPoint, iam404, rittesh.patel, vishalkakadiya, BhargavBhandari90, bryant1410, 1gor, matt-h, dotsam, nathanielks, rigagoogoo, dslatten, jinschoi, kelin1003, vaishuagola27, rahulsprajapati, utkarshpatel, gsayed786, shashwatmittal, sudhiryadav, thrijith, stayallive, jaredwsmith, abhijitrakas, umeshnevase, sid177, souptik, arafatkn, subscriptiongroup, akrocks, vedantgandhi28, GridPane, stefanfisk, SGr33n, agvs, diepbui4157, pratiklondhe, webdados, ghost, ravanh
+**Contributors:** rtcamp, rahul286, saurabhshukla, manishsongirkar36, faishal, desaiuditd, darren-slatten, jk3us, daankortenbach, telofy, pjv, llonchj, jinnko, weskoop, bcole808, gungeekatx, rohanveer, chandrapatel, gagan0123, ravanh, michaelbeil, samedwards, niwreg, entr, nuvoPoint, iam404, rittesh.patel, vishalkakadiya, BhargavBhandari90, bryant1410, 1gor, matt-h, dotsam, nathanielks, rigagoogoo, dslatten, jinschoi, kelin1003, vaishuagola27, rahulsprajapati, utkarshpatel, gsayed786, shashwatmittal, sudhiryadav, thrijith, stayallive, jaredwsmith, abhijitrakas, umeshnevase, sid177, souptik, arafatkn, subscriptiongroup, akrocks, vedantgandhi28, GridPane, stefanfisk, SGr33n, agvs, diepbui4157, pratiklondhe, webdados, ghost, ravanh, tjalexander70, mrrobot47
 
 **Tags:** nginx, cache-purge, fastcgi, permalinks, redis-cache
 
@@ -9,7 +9,7 @@
 
 **Tested up to:** 6.8
 
-**Stable tag:** 2.3.4
+**Stable tag:** 2.3.5
 
 **License:** GPLv2 or later (of-course)
 
@@ -164,6 +164,10 @@ Please post your problem in [our free support forum](https://github.com/rtCamp/n
 ![Remaining settings](https://ps.w.org/nginx-helper/assets/screenshot-2.png)
 
 ## Changelog ##
+
+### 2.3.5 ###
+
+* Purge not working. [#Issue](https://wordpress.org/support/topic/purge-not-working-7/) - by [tjalexander70](https://profiles.wordpress.org/tjalexander70/), [mrrobot47](https://github.com/mrrobot47)
 
 ### 2.3.4 ###
 

--- a/includes/class-nginx-helper-activator.php
+++ b/includes/class-nginx-helper-activator.php
@@ -40,6 +40,25 @@ class Nginx_Helper_Activator {
 			return;
 		}
 
+		self::set_user_caps();
+
+		wp_schedule_event( time(), 'daily', 'rt_wp_nginx_helper_check_log_file_size_daily' );
+		
+		if( method_exists( $nginx_helper_admin, 'store_default_options' ) ) {
+			$nginx_helper_admin->store_default_options();
+		}
+
+	}
+
+	/**
+	 * This functions sets the user capabilites appropriately.
+	 */
+	public static function set_user_caps() {
+
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
 		$role = get_role( 'administrator' );
 
 		if ( empty( $role ) ) {
@@ -55,12 +74,6 @@ class Nginx_Helper_Activator {
 
 		$role->add_cap( 'Nginx Helper | Config' );
 		$role->add_cap( 'Nginx Helper | Purge cache' );
-
-		wp_schedule_event( time(), 'daily', 'rt_wp_nginx_helper_check_log_file_size_daily' );
-		
-		if( method_exists( $nginx_helper_admin, 'store_default_options' ) ) {
-			$nginx_helper_admin->store_default_options();
-		}
 
 	}
 

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -77,7 +77,7 @@ class Nginx_Helper {
 	public function __construct() {
 
 		$this->plugin_name = 'nginx-helper';
-		$this->version     = '2.3.4';
+		$this->version     = '2.3.5';
 		$this->minimum_wp  = '3.0';
 
 		if ( ! $this->required_wp_version() ) {

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Nginx Helper
  * Plugin URI:        https://rtcamp.com/nginx-helper/
  * Description:       Cleans nginx's fastcgi/proxy cache or redis-cache whenever a post is edited/published. Also does few more things.
- * Version:           2.3.4
+ * Version:           2.3.5
  * Author:            rtCamp
  * Author URI:        https://rtcamp.com
  * Text Domain:       nginx-helper

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -72,27 +72,39 @@ function handle_nginx_helper_upgrade( $upgrader_object, $options ) {
 		return;
 	}
 
-	if ( ! array_key_exists( 'type', $options ) || ! array_key_exists( 'action', $options ) || ! array_key_exists( 'plugins', $options ) ) {
+	if ( ! array_key_exists( 'type', $options ) || ! array_key_exists( 'action', $options ) ) {
 		return;
 	}
 
-	if ( 'update' !== $options['action'] || 'plugin' !== $options['type'] || ! is_array( $options['plugins'] ) ) {
+	if ( 'plugin' !== $options['type'] ||  ! in_array( $options['action'], [ 'install', 'update' ] ) ) {
 		return;
 	}
 
-	foreach ( $options['plugins'] as $plugin ) {
-		if ( $plugin === NGINX_HELPER_BASENAME ) {
-
-			// Run the user capabilities when plugin is updated.
-			Nginx_Helper_Activator::set_user_caps();
+	if ( 'update' === $options['action'] ) {
+		if ( ! is_array( $options['plugins'] ) || 
+			! in_array( NGINX_HELPER_BASENAME, $options['plugins'] ) ) {
+			return;
+		}
+		
+	}
+	
+	if ( 'install' === $options['action'] ) {
+    
+		if ( ! is_array( $upgrader_object->result ) || 
+			! array_key_exists( 'destination_name', $upgrader_object->result ) || 
+			$upgrader_object->result['destination_name'] !== dirname( NGINX_HELPER_BASENAME ) ) {
+			return;
 		}
 	}
+	
+	require_once NGINX_HELPER_BASEPATH . 'includes/class-nginx-helper-activator.php';
+	Nginx_Helper_Activator::set_user_caps();
 
 }
 
 register_activation_hook( __FILE__, 'activate_nginx_helper' );
 register_deactivation_hook( __FILE__, 'deactivate_nginx_helper' );
-add_action( 'upgrader_process_complete', 'handle_nginx_helper_upgrade', 10, 2 );
+add_action( 'upgrader_process_complete', 'handle_nginx_helper_upgrade', 1, 2 );
 
 /**
  * The core plugin class that is used to define internationalization,

--- a/nginx-helper.php
+++ b/nginx-helper.php
@@ -60,8 +60,39 @@ function deactivate_nginx_helper() {
 	Nginx_Helper_Deactivator::deactivate();
 }
 
+/**
+ * The code that runs during plugin upgrade.
+ *
+ * @param WP_Upgrader $upgrader_object The Wordpress Upgrader Object.
+ * @param array       $options The options for the upgrade process.
+ */
+function handle_nginx_helper_upgrade( $upgrader_object, $options ) {
+
+	if ( ! is_array( $options ) ) {
+		return;
+	}
+
+	if ( ! array_key_exists( 'type', $options ) || ! array_key_exists( 'action', $options ) || ! array_key_exists( 'plugins', $options ) ) {
+		return;
+	}
+
+	if ( 'update' !== $options['action'] || 'plugin' !== $options['type'] || ! is_array( $options['plugins'] ) ) {
+		return;
+	}
+
+	foreach ( $options['plugins'] as $plugin ) {
+		if ( $plugin === NGINX_HELPER_BASENAME ) {
+
+			// Run the user capabilities when plugin is updated.
+			Nginx_Helper_Activator::set_user_caps();
+		}
+	}
+
+}
+
 register_activation_hook( __FILE__, 'activate_nginx_helper' );
 register_deactivation_hook( __FILE__, 'deactivate_nginx_helper' );
+add_action( 'upgrader_process_complete', 'handle_nginx_helper_upgrade', 10, 2 );
 
 /**
  * The core plugin class that is used to define internationalization,

--- a/readme.txt
+++ b/readme.txt
@@ -1,13 +1,13 @@
 === Nginx Helper ===
-Contributors: rtcamp, rahul286, saurabhshukla, manishsongirkar36, faishal, desaiuditd, darren-slatten, jk3us, daankortenbach, telofy, pjv, llonchj, jinnko, weskoop, bcole808, gungeekatx, rohanveer, chandrapatel, gagan0123, ravanh, michaelbeil, samedwards, niwreg, entr, nuvoPoint, iam404, rittesh.patel, vishalkakadiya, BhargavBhandari90, bryant1410, 1gor, matt-h, dotsam, nathanielks, rigagoogoo, dslatten, jinschoi, kelin1003, vaishuagola27, rahulsprajapati, utkarshpatel, gsayed786, shashwatmittal, sudhiryadav, thrijith, stayallive, jaredwsmith, abhijitrakas, umeshnevase, sid177, souptik, arafatkn, subscriptiongroup, akrocks, vedantgandhi28, GridPane, agvs, diepbui4157, pratiklondhe, ravanh
-Unlinked Contributors: stefanfisk, SGr33n, webdados, ghost
+Contributors: rtcamp, rahul286, saurabhshukla, manishsongirkar36, faishal, desaiuditd, darren-slatten, jk3us, daankortenbach, telofy, pjv, llonchj, jinnko, weskoop, bcole808, gungeekatx, rohanveer, chandrapatel, gagan0123, ravanh, michaelbeil, samedwards, niwreg, entr, nuvoPoint, iam404, rittesh.patel, vishalkakadiya, BhargavBhandari90, bryant1410, 1gor, matt-h, dotsam, nathanielks, rigagoogoo, dslatten, jinschoi, kelin1003, vaishuagola27, rahulsprajapati, utkarshpatel, gsayed786, shashwatmittal, sudhiryadav, thrijith, stayallive, jaredwsmith, abhijitrakas, umeshnevase, sid177, souptik, arafatkn, subscriptiongroup, akrocks, vedantgandhi28, GridPane, agvs, diepbui4157, pratiklondhe, ravanh, tjalexander70
+Unlinked Contributors: stefanfisk, SGr33n, webdados, ghost, mrrobot47
 Donate Link: http://rt.cx/eedonate/
 Tags: nginx, cache-purge, fastcgi, permalinks, redis-cache
 License: GPLv2 or later (of-course)
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 3.0
 Tested up to: 6.8
-Stable tag: 2.3.4
+Stable tag: 2.3.5
 
 Cleans nginx's fastcgi/proxy cache or redis-cache whenever a post is edited/published. Also does a few more things.
 
@@ -151,6 +151,11 @@ Please post your problem in [our free support forum](https://github.com/rtCamp/n
 2. Remaining settings
 
 == Changelog ==
+
+= 2.3.5 =
+
+* Purge not working. [#Issue](https://wordpress.org/support/topic/purge-not-working-7/) - by [tjalexander70](https://profiles.wordpress.org/tjalexander70/), [mrrobot47](https://github.com/mrrobot47)
+
 
 = 2.3.4 =
 


### PR DESCRIPTION
## Changes made
- Add a fix to add capability for admin on plugin update.
- Bump plugin version to 2.3.5

## Testing
- Ensure your plugin version is lower and you do not deactivate and activate the plugin manually.
- Go to Upload Plugin
- Upload the plugin zip file there.
- Once done ensure that the Administrator still has the permission to purge cache.

## Issue
- https://github.com/rtCamp/nginx-helper/issues/431