### PR TITLE
Remove Version option from DB on deactivate

### DIFF
--- a/includes/class-nginx-helper-deactivator.php
+++ b/includes/class-nginx-helper-deactivator.php
@@ -33,6 +33,8 @@ class Nginx_Helper_Deactivator {
 		$role->remove_cap( 'Nginx Helper | Config' );
 		$role->remove_cap( 'Nginx Helper | Purge cache' );
 
+		delete_option( 'nginx_helper_version' );
+
 	}
 
 }


### PR DESCRIPTION
## Changes Made
- Remove the version option from DB on plugin uninstall.

## Issue
Ref: https://github.com/rtCamp/nginx-helper/issues/431