### PR TITLE
Add Auto-Purge Suggestion After WordPress Core, Plugin, or Theme Updates [develop]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Yes. It handles all post-types the same way.
 
 **Q. How can I purge cache automatically after WordPress/plugin/theme updates?**
 
-Yes. By default, Nginx Helper does **not** purge cache on WordPress core, plugin, or theme updates.  
+By default, Nginx Helper does **not** purge cache on WordPress core, plugin, or theme updates.  
 If you want this behavior, you can enable it using a filter:
 
 `add_filter( 'rt_wp_nginx_helper_enable_auto_purge_on_any_update', '__return_true' );`

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Replace the path with your own.
 
 Yes. It handles all post-types the same way.
 
+**Q. How can I purge cache automatically after WordPress/plugin/theme updates?**
+
+Yes. By default, Nginx Helper does **not** purge cache on WordPress core, plugin, or theme updates.  
+If you want this behavior, you can enable it using a filter:
+
+`add_filter( 'rt_wp_nginx_helper_enable_auto_purge_on_any_update', '__return_true' );`
+
+Once enabled, cache will be purged automatically whenever WordPress core, plugins, or themes are updated.  
+If left disabled (default), Nginx Helper will instead show an admin notice after updates, reminding you to purge cache manually.
+
 **Q. How do I know my Nginx config is correct for fastcgi purging?**
 
 Manually purging any page from the cache, by following instructions in the previous answer.

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -1013,7 +1013,7 @@ class Nginx_Helper_Admin {
 		<div class="notice notice-info">
 			<p>
 				<?php
-			esc_html_e( 'A WordPress update was detected. It is recommended to purge the cache to ensure your site displays the latest changes.', 'nginx-helper' );
+				esc_html_e( 'A WordPress update was detected. It is recommended to purge the cache to ensure your site displays the latest changes.', 'nginx-helper' );
 				?>
 				<a href="<?php echo esc_url( $settings_link ); ?>"><?php esc_html_e( 'Go & Purge Cache', 'nginx-helper' ); ?></a>
 				|

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -225,7 +225,7 @@ class Nginx_Helper_Admin {
 			array(
 				'nginx_helper_action'  => 'purge',
 				'nginx_helper_urls'    => $nginx_helper_urls,
-				'nginx_helper_dismiss' => get_transient( 'nginx_helper_suggest_purge_notice' ),
+				'nginx_helper_dismiss' => get_transient( 'rt_wp_nginx_helper_suggest_purge_notice' ),
 			)
 		);
 		
@@ -979,7 +979,7 @@ class Nginx_Helper_Admin {
 	 * Automatically purges Nginx cache on any WordPress core, plugin, or theme update if enabled.
 	 *
 	 * @param WP_Upgrader $upgrader_object WP_Upgrader instance.
-	 * @param array       $options Array of bulk item update data..
+	 * @param array       $options Array of bulk item update data.
 	 */
 	public function nginx_helper_auto_purge_on_any_update( $upgrader_object, $options ) {
 
@@ -989,7 +989,7 @@ class Nginx_Helper_Admin {
 			return;
 		}
 		if ( ! defined( 'NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE' ) || ! NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE ) {
-			set_transient( 'nginx_helper_suggest_purge_notice', true, HOUR_IN_SECONDS );
+			set_transient( 'rt_wp_nginx_helper_suggest_purge_notice', true, HOUR_IN_SECONDS );
 			return;
 		}
 		global $nginx_purger;
@@ -1002,7 +1002,7 @@ class Nginx_Helper_Admin {
 	 */
 	public function suggest_purge_after_update() {
 
-		if ( ! get_transient( 'nginx_helper_suggest_purge_notice' ) ) {
+		if ( ! get_transient( 'rt_wp_nginx_helper_suggest_purge_notice' ) ) {
 			return;
 		}
 
@@ -1043,7 +1043,7 @@ class Nginx_Helper_Admin {
 
 		if ( $dismiss && $nonce_verified ) {
 
-			delete_transient( 'nginx_helper_suggest_purge_notice' );
+			delete_transient( 'rt_wp_nginx_helper_suggest_purge_notice' );
 			wp_safe_redirect( remove_query_arg( array( 'nginx_helper_dismiss', '_wpnonce' ) ) );
 			exit;
 		}

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -223,8 +223,9 @@ class Nginx_Helper_Admin {
 		
 		$purge_url = add_query_arg(
 			array(
-				'nginx_helper_action' => 'purge',
-				'nginx_helper_urls'   => $nginx_helper_urls,
+				'nginx_helper_action'  => 'purge',
+				'nginx_helper_urls'    => $nginx_helper_urls,
+				'nginx_helper_dismiss' => get_transient( 'nginx_helper_suggest_purge_notice' ),
 			)
 		);
 		
@@ -971,6 +972,80 @@ class Nginx_Helper_Admin {
 
 			// If selected, make sure cap is added.
 			$role->add_cap( $purge_cap );
+		}
+	}
+
+	/**
+	 * Automatically purges Nginx cache on any WordPress core, plugin, or theme update if enabled.
+	 *
+	 * @param WP_Upgrader $upgrader_object WP_Upgrader instance.
+	 * @param array       $options Array of bulk item update data..
+	 */
+	public function nginx_helper_auto_purge_on_any_update( $upgrader_object, $options ) {
+
+		if ( ! isset( $options['action'], $options['type'] )
+			|| 'update' !== $options['action']
+			|| ! in_array( $options['type'], array( 'core', 'plugin', 'theme' ), true ) ) {
+			return;
+		}
+		if ( ! defined( 'NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE' ) || ! NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE ) {
+			set_transient( 'nginx_helper_suggest_purge_notice', true, HOUR_IN_SECONDS );
+			return;
+		}
+		global $nginx_purger;
+
+		$nginx_purger->purge_all();
+	}
+
+	/**
+	 * Displays an admin notice suggesting the user to purge cache after a WordPress update.
+	 */
+	public function suggest_purge_after_update() {
+
+		if ( ! get_transient( 'nginx_helper_suggest_purge_notice' ) ) {
+			return;
+		}
+
+		$setting_page  = is_network_admin() ? 'settings.php' : 'options-general.php';
+		$settings_link = network_admin_url( $setting_page . '?page=nginx' );
+		$dismiss_url   = wp_nonce_url( add_query_arg( 'nginx_helper_dismiss', 'true' ), 'nginx_helper_dismiss_notice' );
+		?>
+		<div class="notice notice-info">
+			<p>
+				<?php
+				echo esc_html__( 'A WordPress update was detected. It is recommended to purge the cache to ensure your site displays the latest changes.', 'nginx-helper' );
+				?>
+				<a href="<?php echo esc_url( $settings_link ); ?>"><?php esc_html_e( 'Go & Purge Cache', 'nginx-helper' ); ?></a>
+				|
+				<a href="<?php echo esc_url( $dismiss_url ); ?>">
+				<?php esc_html_e( 'Dismiss', 'nginx-helper' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Dismisses the "suggest purge" admin notice when the user clicks the dismiss link.
+	 */
+	public function dismiss_suggest_purge_after_update() {
+
+		if ( ! isset( $_GET['nginx_helper_dismiss'] ) || ! isset( $_GET['_wpnonce'] ) ) {
+			return;
+		}
+
+		$dismiss          = sanitize_text_field( wp_unslash( $_GET['nginx_helper_dismiss'] ) );
+		$nonce            = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
+
+		// Verify the correct nonce depending on whether this is a purge+dismiss or dismiss-only request.
+		$has_purge_params = isset( $_GET['nginx_helper_action'], $_GET['nginx_helper_urls'] );
+		$nonce_verified   = $has_purge_params ? wp_verify_nonce( $nonce, 'nginx_helper-purge_all' ) : wp_verify_nonce( $nonce, 'nginx_helper_dismiss_notice' );
+
+		if ( $dismiss && $nonce_verified ) {
+
+			delete_transient( 'nginx_helper_suggest_purge_notice' );
+			wp_safe_redirect( remove_query_arg( array( 'nginx_helper_dismiss', '_wpnonce' ) ) );
+			exit;
 		}
 	}
 }

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -1013,7 +1013,7 @@ class Nginx_Helper_Admin {
 		<div class="notice notice-info">
 			<p>
 				<?php
-				echo esc_html__( 'A WordPress update was detected. It is recommended to purge the cache to ensure your site displays the latest changes.', 'nginx-helper' );
+			esc_html_e( 'A WordPress update was detected. It is recommended to purge the cache to ensure your site displays the latest changes.', 'nginx-helper' );
 				?>
 				<a href="<?php echo esc_url( $settings_link ); ?>"><?php esc_html_e( 'Go & Purge Cache', 'nginx-helper' ); ?></a>
 				|

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -774,7 +774,7 @@ if ( is_multisite() ) {
 						<label for="enable_auto_purge">
 							<input
 							disabled
-							type="checkbox" value="1" id="enable_auto_purge" name="enable_auto_purge" <?php checked( NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE, 1 ); ?> />
+							type="checkbox" id="enable_auto_purge" name="enable_auto_purge" <?php checked( NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE, 1 ); ?> />
 							&nbsp;
 							<?php
 							esc_html_e( 'Auto Purge when Core, Plugin or Theme updates.', 'nginx-helper' );
@@ -783,9 +783,21 @@ if ( is_multisite() ) {
 						<p>
 						<?php
 						if ( NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE ) {
-							echo wp_kses_post( __( '(NOTE: This feature is enabled via the <strong>rt_wp_nginx_helper_enable_auto_purge_on_any_update</strong> filter. To disable, remove this filter from your code.)', 'nginx-helper' ) );
+							echo wp_kses_post(
+								sprintf(
+									/* translators: %1$s: Filter name 'rt_wp_nginx_helper_enable_auto_purge_on_any_update' */
+									__( '(NOTE: This feature is enabled via the %1$s filter. To disable, remove this filter from your code.)', 'nginx-helper' ),
+									'<strong>rt_wp_nginx_helper_enable_auto_purge_on_any_update</strong>'
+								)
+							);
 						} else {
-							echo wp_kses_post( __( '(NOTE: To enable, return true in the <strong>rt_wp_nginx_helper_enable_auto_purge_on_any_update</strong> filter.)', 'nginx-helper' ) );
+							echo wp_kses_post(
+								sprintf(
+									/* translators: %1$s: Filter name 'rt_wp_nginx_helper_enable_auto_purge_on_any_update' */
+									__( '(NOTE: To enable, return true in the %1$s filter.)', 'nginx-helper' ),
+									'<strong>rt_wp_nginx_helper_enable_auto_purge_on_any_update</strong>'
+								)
+							);
 						}
 						?>
 						</p>

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -765,6 +765,33 @@ if ( is_multisite() ) {
 						</td>
 					</tr>
 				</table>
+				<table class="form-table rtnginx-table">
+					<tr valign="top">
+						<th scope="row">
+							<h4><?php esc_html_e( 'Advance conditions:', 'nginx-helper' ); ?></h4>
+						</th>
+						<td>
+						<label for="enable_auto_purge">
+							<input
+							disabled
+							type="checkbox" value="1" id="enable_auto_purge" name="enable_auto_purge" <?php checked( NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE, 1 ); ?> />
+							&nbsp;
+							<?php
+							esc_html_e( 'Auto Purge when Core, Plugin or Theme updates.', 'nginx-helper' );
+							?>
+						</label>
+						<p>
+						<?php
+						if ( NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE ) {
+							echo wp_kses_post( __( '(NOTE: This feature is enabled via the <strong>rt_wp_nginx_helper_enable_auto_purge_on_any_update</strong> filter. To disable, remove this filter from your code.)', 'nginx-helper' ) );
+						} else {
+							echo wp_kses_post( __( '(NOTE: To enable, return true in the <strong>rt_wp_nginx_helper_enable_auto_purge_on_any_update</strong> filter.)', 'nginx-helper' ) );
+						}
+						?>
+						</p>
+						</td>
+					</tr>
+				</table>
 			</div> <!-- End of .inside -->
 		</div>
 		<div class="postbox">

--- a/admin/partials/nginx-helper-sidebar-display.php
+++ b/admin/partials/nginx-helper-sidebar-display.php
@@ -14,7 +14,7 @@ $purge_url  = add_query_arg(
 	array(
 		'nginx_helper_action'  => 'purge',
 		'nginx_helper_urls'    => 'all',
-		'nginx_helper_dismiss' => get_transient( 'nginx_helper_suggest_purge_notice' ),
+		'nginx_helper_dismiss' => get_transient( 'rt_wp_nginx_helper_suggest_purge_notice' ),
 	)
 );
 $nonced_url = wp_nonce_url( $purge_url, 'nginx_helper-purge_all' );

--- a/admin/partials/nginx-helper-sidebar-display.php
+++ b/admin/partials/nginx-helper-sidebar-display.php
@@ -12,8 +12,9 @@
 
 $purge_url  = add_query_arg(
 	array(
-		'nginx_helper_action' => 'purge',
-		'nginx_helper_urls'   => 'all',
+		'nginx_helper_action'  => 'purge',
+		'nginx_helper_urls'    => 'all',
+		'nginx_helper_dismiss' => get_transient( 'nginx_helper_suggest_purge_notice' ),
 	)
 );
 $nonced_url = wp_nonce_url( $purge_url, 'nginx_helper-purge_all' );

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -89,6 +89,15 @@ class Nginx_Helper {
 			define( 'RT_WP_NGINX_HELPER_CACHE_PATH', $cache_path  );
 		}
 
+		/**
+		 * Flag to automatically purge Nginx cache on any WordPress update (core, plugin, theme).
+		 * Set to true to enable auto-purge; false to disable.
+		 */
+		if ( ! defined( 'NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE' ) ) {
+			$enabled = (bool) apply_filters( 'rt_wp_nginx_helper_enable_auto_purge_on_any_update', false );
+			define( 'NGINX_HELPER_AUTO_PURGE_ON_ANY_UPDATE', $enabled );
+		}
+
 		$this->load_dependencies();
 		$this->set_locale();
 		$this->define_admin_hooks();
@@ -235,6 +244,11 @@ class Nginx_Helper {
 
 		// add action to update purge caps.
 		$this->loader->add_action( 'update_site_option_rt_wp_nginx_helper_options', $nginx_helper_admin, 'nginx_helper_update_role_caps' );
+
+		// advance purge settings.
+		$this->loader->add_action( 'upgrader_process_complete', $nginx_helper_admin, 'nginx_helper_auto_purge_on_any_update', 10, 2 );
+		$this->loader->add_action( 'admin_notices', $nginx_helper_admin, 'suggest_purge_after_update' );
+		$this->loader->add_action( 'admin_init', $nginx_helper_admin, 'dismiss_suggest_purge_after_update' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ Yes. It handles all post-types the same way.
 
 **Q. How can I purge cache automatically after WordPress/plugin/theme updates?**
 
-Yes. By default, Nginx Helper does **not** purge cache on WordPress core, plugin, or theme updates.  
+By default, Nginx Helper does **not** purge cache on WordPress core, plugin, or theme updates.  
 If you want this behavior, you can enable it using a filter:
 
 `add_filter( 'rt_wp_nginx_helper_enable_auto_purge_on_any_update', '__return_true' );`

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,16 @@ Replace the path with your own.
 
 Yes. It handles all post-types the same way.
 
+**Q. How can I purge cache automatically after WordPress/plugin/theme updates?**
+
+Yes. By default, Nginx Helper does **not** purge cache on WordPress core, plugin, or theme updates.  
+If you want this behavior, you can enable it using a filter:
+
+`add_filter( 'rt_wp_nginx_helper_enable_auto_purge_on_any_update', '__return_true' );`
+
+Once enabled, cache will be purged automatically whenever WordPress core, plugins, or themes are updated.  
+If left disabled (default), Nginx Helper will instead show an admin notice after updates, reminding you to purge cache manually.
+
 **Q. How do I know my Nginx config is correct for fastcgi purging?**
 
 Manually purging any page from the cache, by following instructions in the previous answer.


### PR DESCRIPTION
## What
This PR adds a mechanism to suggest or automatically purge cache after WordPress core, a plugin, or a theme updates.

- By default, auto-purge is disabled.
- Developers can enable it via the filter:
`add_filter( 'rt_wp_nginx_helper_enable_auto_purge_on_any_update', '__return_true' );`
- If auto-purge is disabled (default), the plugin shows an admin notice prompting users to purge the cache manually after an update.
- Dismissing the notice or performing a purge clears the notice.
- The settings page displays a disabled checkbox showing the current auto-purge status and instructions regarding the filter.

Closes:- [WordPress Support Thread](https://wordpress.org/support/topic/auto-purge-option-having-issue-with-slider-revolution/)

## Why

- To ensure users’ sites always reflect the latest changes after core, plugin, or theme updates.
- Automatic purging is safer for advanced users who want full automation.
- For users who prefer manual control, the plugin provides a notice suggesting a purge.
- Using a filter keeps this feature programmatic, preventing accidental cache purges by non-technical users.

## How

- Added `nginx_helper_auto_purge_on_any_update()` hooked into `upgrader_process_complete` to detect updates.
- If the filter returns true, cache is purged automatically.
- If the filter returns false or is not set, a transient is created to trigger an admin notice.
- `suggest_purge_after_update()` displays the notice with “Go & Purge Cache” and “Dismiss” links.
- `dismiss_suggest_purge_after_update()` clears the transient when the notice is dismissed.
- Settings page checkbox reflects the auto-purge status and shows filter instructions.

## Testing Instructions

1. Enable/disable the auto purge via `rt_wp_nginx_helper_enable_auto_purge_on_any_update` filter.
2. Update WordPress core, a plugin, or a theme.
3. Verify behavior based on the filter:
    1. Enabled: Cache should be automatically purged.
    2. Disabled / no filter: Admin notice appears suggesting a purge.
4. Click “Go & Purge Cache” in the notice, It should take you to the nginx-helper settings page.
5. Purging the cache should also dismiss the notice.
6. Click “Dismiss” in the notice, Notice disappears and transient is removed.
7. Check the settings page checkbox, should accurately reflect the status set by the filter, with instructions for enabling/disabling.
