### PR TITLE
Feat: Extend WooCommerce Purging Functionality For REST API [master]

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If enabled, cache for purchased products or products updated via REST API will b
 To use it:
 
 1. Go to Nginx Helper → Settings → WooCommerce Options.
-2. Tick “Purge product cache on product updates”.
+2. Tick “Purge product cache on updates”.
 
 This ensures customers always see up-to-date stock status and product information without stale cache.
 

--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ Yes. When setting the URL structure in Nginx configuration file a trailing slash
 **Q. How can I automatically purge cache when WooCommerce product stock reduces after purchase?**
 
 Nginx Helper now includes optional WooCommerce integration.
-If enabled, cache for purchased products will be purged automatically whenever stock is reduced after an order.
+If enabled, cache for purchased products or products updated via REST API will be purged automatically.
 
 To use it:
 
 1. Go to Nginx Helper → Settings → WooCommerce Options.
-2. Tick “Purge product cache on stock change or purchase”.
+2. Tick “Purge product cache on product updates”.
 
-This ensures customers always see up-to-date stock status without stale cache.
+This ensures customers always see up-to-date stock status and product information without stale cache.
 
 Note: This option will only be visible if WooCommerce is active.
 

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -1027,6 +1027,13 @@ class Nginx_Helper_Admin {
 		}
 	}
 
+	/**
+	 * Purge product cache when a product is updated via REST API.
+	 *
+	 * @since 2.3.5
+	 * @global object $nginx_purger Nginx purger object.
+	 * @param int $product_id Product ID.
+	 */
 	public function purge_product_cache_on_update( $product_id ) {
 		global $nginx_purger;
 

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -1037,6 +1037,10 @@ class Nginx_Helper_Admin {
 	public function purge_product_cache_on_update( $product_id ) {
 		global $nginx_purger;
 
+		if ( empty( $nginx_purger ) ) { 
+			return; 
+		}
+
 		if ( ! $this->options['enable_purge'] ) {
 			return;
 		}

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -295,7 +295,6 @@ class Nginx_Helper_Admin {
 			'is_cache_preloaded'               => 0,
 			'roles_with_purge_cap'             => array(),
 			'purge_woo_products'               => 0,
-			'purge_woo_rest'				   => 0,
 		);
 	
 	}
@@ -982,19 +981,12 @@ class Nginx_Helper_Admin {
 	 * @since 2.3.5
 	 */
 	public function init_woocommerce_hooks() {
-		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) || empty( $this->options['purge_woo_products'] ) ) {
 			return;
 		}
 	
-		// Purge on purchase (stock reduction).
-		if ( ! empty( $this->options['purge_woo_products'] ) ) {
-			add_action( 'woocommerce_reduce_order_stock', array( $this, 'purge_product_cache_on_purchase' ), 10, 1 );
-		}
-	
-		// Purge on product update (Admin, REST, programmatic).
-		if ( ! empty( $this->options['purge_woo_rest'] ) ) {
-			add_action( 'woocommerce_update_product', array( $this, 'purge_product_cache_on_update' ), 10, 1 );
-		}
+		add_action( 'woocommerce_reduce_order_stock', array( $this, 'purge_product_cache_on_purchase' ), 10, 1 );
+		add_action( 'woocommerce_update_product', array( $this, 'purge_product_cache_on_update' ), 10, 1 );
 	}
 	
 

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -295,6 +295,7 @@ class Nginx_Helper_Admin {
 			'is_cache_preloaded'               => 0,
 			'roles_with_purge_cap'             => array(),
 			'purge_woo_products'               => 0,
+			'purge_woo_rest'				   => 0,
 		);
 	
 	}
@@ -981,12 +982,21 @@ class Nginx_Helper_Admin {
 	 * @since 2.3.5
 	 */
 	public function init_woocommerce_hooks() {
-		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) || empty( $this->options['purge_woo_products'] ) ) {
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 			return;
 		}
-
-		add_action( 'woocommerce_reduce_order_stock', array( $this, 'purge_product_cache_on_purchase' ), 10, 1 );
+	
+		// Purge on purchase (stock reduction).
+		if ( ! empty( $this->options['purge_woo_products'] ) ) {
+			add_action( 'woocommerce_reduce_order_stock', array( $this, 'purge_product_cache_on_purchase' ), 10, 1 );
+		}
+	
+		// Purge on product update (Admin, REST, programmatic).
+		if ( ! empty( $this->options['purge_woo_rest'] ) ) {
+			add_action( 'woocommerce_update_product', array( $this, 'purge_product_cache_on_update' ), 10, 1 );
+		}
 	}
+	
 
 	/**
 	 * Purge product cache when order stock is reduced (purchase).
@@ -1025,4 +1035,21 @@ class Nginx_Helper_Admin {
 			}
 		}
 	}
+
+	public function purge_product_cache_on_update( $product_id ) {
+		global $nginx_purger;
+
+		if ( ! $this->options['enable_purge'] ) {
+			return;
+		}
+	
+		$nginx_purger->log( 'WooCommerce product update - purging cache for product ID: ' . $product_id );
+	
+		$product_url = get_permalink( $product_id );
+	
+		if ( $product_url ) {
+			$nginx_purger->purge_url( $product_url );
+		}
+	}
+	
 }

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -988,7 +988,7 @@ class Nginx_Helper_Admin {
 		add_action( 'woocommerce_reduce_order_stock', array( $this, 'purge_product_cache_on_purchase' ), 10, 1 );
 		add_action( 'woocommerce_update_product', array( $this, 'purge_product_cache_on_update' ), 10, 1 );
 	}
-	
+
 	/**
 	 * Purge product cache when order stock is reduced (purchase).
 	 *

--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -984,12 +984,11 @@ class Nginx_Helper_Admin {
 		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) || empty( $this->options['purge_woo_products'] ) ) {
 			return;
 		}
-	
+
 		add_action( 'woocommerce_reduce_order_stock', array( $this, 'purge_product_cache_on_purchase' ), 10, 1 );
 		add_action( 'woocommerce_update_product', array( $this, 'purge_product_cache_on_update' ), 10, 1 );
 	}
 	
-
 	/**
 	 * Purge product cache when order stock is reduced (purchase).
 	 *

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -1023,7 +1023,7 @@ if ( is_multisite() ) {
 						<td>
 							<input type="checkbox" value="1" id="purge_woo_products" name="purge_woo_products" <?php checked( $nginx_helper_settings['purge_woo_products'] ?? 0, 1 ); ?> />
 							<label for="purge_woo_products">
-								<?php esc_html_e( 'Purge product cache on product updates', 'nginx-helper' ); ?>
+								<?php esc_html_e( 'Purge product cache on updates', 'nginx-helper' ); ?>
 							</label>
 						</td>
 					</tr>

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -49,7 +49,8 @@ $args = array(
 	'purge_amp_urls',
 	'preload_cache',
 	'roles_with_purge_cap',
-	'purge_woo_products'
+	'purge_woo_products',
+	'purge_woo_rest'
 );
 
 $all_inputs = array();
@@ -1024,6 +1025,14 @@ if ( is_multisite() ) {
 							<input type="checkbox" value="1" id="purge_woo_products" name="purge_woo_products" <?php checked( $nginx_helper_settings['purge_woo_products'] ?? 0, 1 ); ?> />
 							<label for="purge_woo_products">
 								<?php esc_html_e( 'Purge product cache on stock change or purchase', 'nginx-helper' ); ?>
+							</label>
+						</td>
+					</tr>
+					<tr valign="top">
+						<td>
+							<input type="checkbox" value="1" id="purge_woo_rest" name="purge_woo_rest" <?php checked( $nginx_helper_settings['purge_woo_rest'] ?? 0, 1 ); ?> />
+							<label for="purge_woo_rest">
+								<?php esc_html_e( 'Enable product cache purge via REST API updates', 'nginx-helper' ); ?>
 							</label>
 						</td>
 					</tr>

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -1023,7 +1023,7 @@ if ( is_multisite() ) {
 						<td>
 							<input type="checkbox" value="1" id="purge_woo_products" name="purge_woo_products" <?php checked( $nginx_helper_settings['purge_woo_products'] ?? 0, 1 ); ?> />
 							<label for="purge_woo_products">
-								<?php esc_html_e( 'Purge product cache on stock change or purchase or REST API update', 'nginx-helper' ); ?>
+								<?php esc_html_e( 'Purge product cache on product updates', 'nginx-helper' ); ?>
 							</label>
 						</td>
 					</tr>

--- a/admin/partials/nginx-helper-general-options.php
+++ b/admin/partials/nginx-helper-general-options.php
@@ -49,8 +49,7 @@ $args = array(
 	'purge_amp_urls',
 	'preload_cache',
 	'roles_with_purge_cap',
-	'purge_woo_products',
-	'purge_woo_rest'
+	'purge_woo_products'
 );
 
 $all_inputs = array();
@@ -1024,15 +1023,7 @@ if ( is_multisite() ) {
 						<td>
 							<input type="checkbox" value="1" id="purge_woo_products" name="purge_woo_products" <?php checked( $nginx_helper_settings['purge_woo_products'] ?? 0, 1 ); ?> />
 							<label for="purge_woo_products">
-								<?php esc_html_e( 'Purge product cache on stock change or purchase', 'nginx-helper' ); ?>
-							</label>
-						</td>
-					</tr>
-					<tr valign="top">
-						<td>
-							<input type="checkbox" value="1" id="purge_woo_rest" name="purge_woo_rest" <?php checked( $nginx_helper_settings['purge_woo_rest'] ?? 0, 1 ); ?> />
-							<label for="purge_woo_rest">
-								<?php esc_html_e( 'Enable product cache purge via REST API updates', 'nginx-helper' ); ?>
+								<?php esc_html_e( 'Purge product cache on stock change or purchase or REST API update', 'nginx-helper' ); ?>
 							</label>
 						</td>
 					</tr>

--- a/readme.txt
+++ b/readme.txt
@@ -105,7 +105,7 @@ If enabled, cache for purchased products or products updated via REST API will b
 To use it:
 
 1. Go to Nginx Helper → Settings → WooCommerce Options.
-2. Tick “Purge product cache on product updates”.
+2. Tick “Purge product cache on updates”.
 
 This ensures customers always see up-to-date stock status and product information without stale cache.
 

--- a/readme.txt
+++ b/readme.txt
@@ -100,14 +100,14 @@ Yes. When setting the URL structure in Nginx configuration file a trailing slash
 **Q. How can I automatically purge cache when WooCommerce product stock reduces after purchase?**
 
 Nginx Helper now includes optional WooCommerce integration.
-If enabled, cache for purchased products will be purged automatically whenever stock is reduced after an order.
+If enabled, cache for purchased products or products updated via REST API will be purged automatically.
 
 To use it:
 
 1. Go to Nginx Helper → Settings → WooCommerce Options.
-2. Tick “Purge product cache on stock change or purchase”.
+2. Tick “Purge product cache on product updates”.
 
-This ensures customers always see up-to-date stock status without stale cache.
+This ensures customers always see up-to-date stock status and product information without stale cache.
 
 Note: This option will only be visible if WooCommerce is active.
 


### PR DESCRIPTION
### Description

Added cache purging for WooCommerce products when updated via REST AP. Hooked into the WooCommerce product update hook to trigger purging after a product is updated. This ensures the frontend always serves fresh product data after updates via REST API.


### Testing Instructions

1. Enable REST API in WooCommerce settings.
2. Optionally, relax permissions while testing by adding a filter to allow all REST API requests. ( Snippet down below)
3. Use Postman or Thunder Client to make a request to a specific product endpoint. Update any detail of your choice, for example the stock quantity.
4. Verify that the product is updated in the Admin.
5. Verify that the product cache is purged by checking that the frontend returns the updated data.

Add this snippet for testing purposes to relax permissions

```
add_filter( 'woocommerce_rest_check_permissions', function( $permission, $context, $object_id, $post_type ) {
    return true;
}, 10, 4 );
```

### Screencast 

External link (Recorded via Loom in a Linux setup)
https://www.loom.com/share/ce38d9b59e554cc99c957bf4d0119697?sid=9ed596af-52b3-4826-adae-37e15b927ee0
