### PR TITLE
Fix undefined array key "scheme" and "host" in FastCGI purger

### DIFF
--- a/admin/class-fastcgi-purger.php
+++ b/admin/class-fastcgi-purger.php
@@ -48,7 +48,7 @@ class FastCGI_Purger extends Purger {
 		switch ( $nginx_helper_admin->options['purge_method'] ) {
 
 			case 'unlink_files':
-				$_url_purge_base = $parse['scheme'] . '://' . $parse['host'] . $parse['path'];
+				$_url_purge_base = ( $parse['scheme'] ?? 'https' ) . '://' . ( $parse['host'] ?? $_SERVER['HTTP_HOST'] ) . ( $parse['path'] ?? '/' );
 				$_url_purge      = $_url_purge_base;
 
 				if ( ! empty( $parse['query'] ) ) {
@@ -143,7 +143,7 @@ class FastCGI_Purger extends Purger {
 		switch ( $nginx_helper_admin->options['purge_method'] ) {
 
 			case 'unlink_files':
-				$_url_purge_base = $parse['scheme'] . '://' . $parse['host'];
+				$_url_purge_base = ( $parse['scheme'] ?? 'https' ) . '://' . ( $parse['host'] ?? $_SERVER['HTTP_HOST'] );
 
 				if ( is_array( $purge_urls ) && ! empty( $purge_urls ) ) {
 
@@ -274,7 +274,7 @@ class FastCGI_Purger extends Purger {
 		// Prevent users from inserting a trailing '/' that could break the url purging.
 		$path = trim( $path, '/' );
 
-		$purge_url_base = $parse['scheme'] . '://' . $parse['host'] . '/' . $path;
+		$purge_url_base = ( $parse['scheme'] ?? 'https' ) . '://' . ( $parse['host'] ?? $_SERVER['HTTP_HOST'] ) . '/' . $path;
 
 		/**
 		 * Filter to change purge URL base for FastCGI cache.


### PR DESCRIPTION
## Problem
When saving a page in Breakdance Builder, the admin-ajax request 
triggers a post save action which calls the FastCGI purger. In 
some cases, parse_url() does not return a "scheme" or "host" key 
(e.g. when the URL passed is relative or malformed), causing a 
fatal 500 error:

> Undefined array key "scheme"
> Undefined array key "host"

## Fix
Added null coalescing fallbacks on 3 locations in class-fastcgi-purger.php:
- `scheme` defaults to `'https'`
- `host` defaults to `$_SERVER['HTTP_HOST']`
- `path` defaults to `'/'`

## Tested on
- WordPress 6.x
- Breakdance Builder
- nginx-helper 2.3.5