### PR TITLE
fix: load plugin textdomain on init instead of plugins_loaded

### DIFF
--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -167,7 +167,7 @@ class Nginx_Helper {
 		$plugin_i18n = new Nginx_Helper_i18n();
 		$plugin_i18n->set_domain( $this->get_plugin_name() );
 
-		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+		$this->loader->add_action( 'init', $plugin_i18n, 'load_plugin_textdomain' );
 
 	}
 


### PR DESCRIPTION
## What

WordPress 6.7 deprecated calling `load_plugin_textdomain()` on the
`plugins_loaded` hook and emits a `_doing_it_wrong()` notice for plugins
that still use the old timing. This moves the hook registration from
`plugins_loaded` to `init`, which is the currently recommended hook.

**Before:**
```php
$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
```

**After:**
```php
$this->loader->add_action( 'init', $plugin_i18n, 'load_plugin_textdomain' );
```

## Background

Prior to WordPress 6.7, `plugins_loaded` was the conventional hook for
loading textdomains. In 6.7, WP core changed the textdomain loading
strategy — plugins bundling `.po`/`.mo` translations now load them
automatically, and the `init` hook is the recommended fallback for
custom translation loading logic. `plugins_loaded` still works in most
cases but produces a deprecation notice that will appear in debug logs.

## Testing

1. Enable `WP_DEBUG` and `WP_DEBUG_LOG`.
2. Activate the plugin on WordPress 6.7+.
3. Confirm no `_doing_it_wrong()` notice for `load_plugin_textdomain` appears in `debug.log`.

Closes #364

---
*Development and testing assisted by AI. All code reviewed and verified manually.*